### PR TITLE
refactor: extract visa eligibility math into testable lib/visa.ts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,9 +85,16 @@ jobs:
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+      - name: Cache Cypress binary
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/Cypress
+          key: cypress-binary-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: Install Cypress binary
+        run: npx cypress install
       - name: Validate secrets
         run: |
           if [ -z "${{ secrets.TURSO_API_TOKEN }}" ] || [ -z "${{ secrets.TURSO_ORGANIZATION_NAME }}" ] || [ -z "${{ secrets.TURSO_TESTING_DATABASE_NAME }}" ] || [ -z "${{ secrets.TURSO_GROUP_NAME }}" ]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn run coverage
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           verbose: true
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Run lint
         run: yarn run lint
@@ -41,7 +48,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Run tests with coverage
         run: yarn run coverage
@@ -65,7 +79,14 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
       - name: Validate secrets
         run: |
@@ -76,12 +97,12 @@ jobs:
       - name: Clean up existing database
         continue-on-error: true
         run: |
-          curl -s -X DELETE \
+          curl -s --retry 3 --retry-delay 2 --retry-connrefused -X DELETE \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases/${{ secrets.TURSO_TESTING_DATABASE_NAME }}"
       - name: Create temporary database
         run: |
-          RESPONSE=$(curl -s -f -X POST \
+          RESPONSE=$(curl -s -f --retry 3 --retry-delay 2 --retry-connrefused -X POST \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d '{"name": "${{ secrets.TURSO_TESTING_DATABASE_NAME }}", "group": "${{ secrets.TURSO_GROUP_NAME }}" }' \
@@ -98,7 +119,7 @@ jobs:
           echo "database_hostname=$HOSTNAME" >> $GITHUB_ENV
       - name: Generate auth token for database
         run: |
-          RESPONSE=$(curl -s -f -X POST \
+          RESPONSE=$(curl -s -f --retry 3 --retry-delay 2 --retry-connrefused -X POST \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases/${{ secrets.TURSO_TESTING_DATABASE_NAME }}/auth/tokens?expiration=30m&authorization=full-access")
@@ -161,6 +182,6 @@ jobs:
       - name: Remove testing database
         if: always()
         run: |
-          curl -s -X DELETE \
+          curl -s --retry 3 --retry-delay 2 --retry-connrefused -X DELETE \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases/${{ secrets.TURSO_TESTING_DATABASE_NAME }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,33 +100,33 @@ jobs:
           curl -s --retry 3 --retry-delay 2 --retry-connrefused -X DELETE \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases/${{ secrets.TURSO_TESTING_DATABASE_NAME }}"
+          # Give the delete a moment to propagate before recreating the same name.
+          sleep 5
       - name: Create temporary database
         run: |
-          RESPONSE=$(curl -s -f --retry 3 --retry-delay 2 --retry-connrefused -X POST \
-            -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"name": "${{ secrets.TURSO_TESTING_DATABASE_NAME }}", "group": "${{ secrets.TURSO_GROUP_NAME }}" }' \
-            "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases")
-          if [ $? -ne 0 ]; then
-            echo "API call failed"
-            exit 1
-          fi
-          HOSTNAME=$(echo $RESPONSE | jq -r '.database.Hostname')
-          if [ -z "$HOSTNAME" ]; then
-            echo "Hostname not found in response"
-            exit 1
-          fi
-          echo "database_hostname=$HOSTNAME" >> $GITHUB_ENV
+          for attempt in 1 2 3 4 5; do
+            HOSTNAME=""
+            RESPONSE=$(curl -s -f --retry 3 --retry-delay 2 --retry-connrefused -X POST \
+              -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
+              -H "Content-Type: application/json" \
+              -d '{"name": "${{ secrets.TURSO_TESTING_DATABASE_NAME }}", "group": "${{ secrets.TURSO_GROUP_NAME }}" }' \
+              "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases") \
+              && HOSTNAME=$(echo "$RESPONSE" | jq -r '.database.Hostname // empty')
+            if [ -n "$HOSTNAME" ]; then
+              echo "database_hostname=$HOSTNAME" >> $GITHUB_ENV
+              exit 0
+            fi
+            echo "Create database attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "Failed to create database after 5 attempts"
+          exit 1
       - name: Generate auth token for database
         run: |
           RESPONSE=$(curl -s -f --retry 3 --retry-delay 2 --retry-connrefused -X POST \
             -H "Authorization: Bearer ${{ secrets.TURSO_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             "${{ env.TURSO_API_URL }}/organizations/${{ secrets.TURSO_ORGANIZATION_NAME }}/databases/${{ secrets.TURSO_TESTING_DATABASE_NAME }}/auth/tokens?expiration=30m&authorization=full-access")
-          if [ $? -ne 0 ]; then
-            echo "API call failed"
-            exit 1
-          fi
           AUTH_TOKEN=$(echo $RESPONSE | jq -r '.jwt')
           if [ -z "$AUTH_TOKEN" ]; then
             echo "AUTH_TOKEN not found in response"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,11 @@ concurrency:
   cancel-in-progress: true
 # Centralize environment variables
 env:
-  NODE_VERSION: '20.x'
+  NODE_VERSION: '22.x'
   TURSO_API_URL: 'https://api.turso.tech/v1'
+
+permissions:
+  contents: read
 jobs:
   # Job for linting
   lint:
@@ -108,6 +111,7 @@ jobs:
             echo "AUTH_TOKEN not found in response"
             exit 1
           fi
+          echo "::add-mask::$AUTH_TOKEN"
           echo "database_auth_token=$AUTH_TOKEN" >> $GITHUB_ENV
       - name: Run database migrations
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Test
 on: [push]
+# Cancel older in-progress runs on the same branch so they don't race each
+# other for the shared Turso testing database (same fixed name every run).
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
 # Centralize environment variables
 env:
   NODE_VERSION: '20.x'
@@ -105,7 +110,16 @@ jobs:
           fi
           echo "database_auth_token=$AUTH_TOKEN" >> $GITHUB_ENV
       - name: Run database migrations
-        run: yarn db:migrate
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if yarn db:migrate; then
+              exit 0
+            fi
+            echo "Migration attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "Migration failed after 5 attempts"
+          exit 1
         env:
           DATABASE_URL: libsql://${{ env.database_hostname }}
           DATABASE_AUTH_TOKEN: ${{ env.database_auth_token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -35,9 +35,9 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -59,9 +59,9 @@ jobs:
     needs: lint
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
@@ -150,7 +150,7 @@ jobs:
           DATABASE_AUTH_TOKEN: ${{ env.database_auth_token }}
       - name: Upload Cypress artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cypress-artifacts
           path: |

--- a/app/_components/visa-summary.tsx
+++ b/app/_components/visa-summary.tsx
@@ -1,4 +1,3 @@
-import { addYears, differenceInYears, subDays } from 'date-fns';
 import {
   AlertTriangle,
   CalendarDays,
@@ -17,7 +16,7 @@ import {
 } from '@/app/_components/ui/card';
 import { Link } from '@/i18n/navigation';
 import { cn, displayUKDateTime } from '@/lib/utils';
-import { YEARS_TO_CITIZENSHIP, YEARS_TO_ILR } from '@/lib/visa';
+import { getVisaStatus } from '@/lib/visa';
 
 type VisaSummaryProps = {
   visaStartDate: Date;
@@ -37,48 +36,20 @@ export async function VisaSummary({
   const t = await getTranslations();
   const today = new Date();
 
-  // Calculate durations and progress
-  const totalVisaDuration = visaExpiryDate.getTime() - visaStartDate.getTime();
-
-  const shouldExtendVisa = differenceInYears(visaExpiryDate, arrivalDate) < 5;
-
-  const applyILRDate = addYears(arrivalDate, YEARS_TO_ILR);
-  const applyCitizenship = addYears(applyILRDate, YEARS_TO_CITIZENSHIP);
-  const daysStayed =
-    (today.getTime() - arrivalDate.getTime()) / (1000 * 60 * 60 * 24);
-  const progressPercentage = Math.round(
-    Math.max(
-      0,
-      Math.min(
-        100,
-        (daysStayed / ((YEARS_TO_ILR + YEARS_TO_CITIZENSHIP) * 365)) * 100
-      )
-    )
-  );
-
-  const daysUntilExpiry = Math.ceil(
-    (visaExpiryDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
-  );
-
-  const arrivalUntilExpiry = Math.ceil(
-    (visaExpiryDate.getTime() - arrivalDate.getTime()) / (1000 * 60 * 60 * 24)
-  );
-
-  const visaExpiryPercentage = Math.round(
-    Math.max(
-      0,
-      Math.min(
-        100,
-        (arrivalUntilExpiry / ((YEARS_TO_ILR + YEARS_TO_CITIZENSHIP) * 365)) *
-          100
-      )
-    )
-  );
-  const isExpiringSoon = daysUntilExpiry <= 30 && daysUntilExpiry > 0;
-  const isExpired = daysUntilExpiry <= 0;
-  const ilrPercentage = Math.round(
-    (YEARS_TO_ILR / (YEARS_TO_ILR + YEARS_TO_CITIZENSHIP)) * 100
-  );
+  const {
+    applyILRDate,
+    applyCitizenshipDate,
+    extendVisaByDate,
+    totalVisaDurationDays,
+    daysSinceArrival,
+    daysUntilExpiry,
+    isExpired,
+    isExpiringSoon,
+    shouldExtendVisa,
+    progressPercentage,
+    visaExpiryPercentage,
+    ilrPercentage,
+  } = getVisaStatus({ visaStartDate, visaExpiryDate, arrivalDate }, today);
 
   const getStatusBadge = () => {
     if (isExpired) {
@@ -134,7 +105,7 @@ export async function VisaSummary({
               </div>
               <div className="flex flex-col items-end">
                 <span>{t('citizenship')}</span>
-                <div>{displayUKDateTime(applyCitizenship, 'P')}</div>
+                <div>{displayUKDateTime(applyCitizenshipDate, 'P')}</div>
                 <div className="w-[1px] h-24 bg-muted-foreground" />
               </div>
             </div>
@@ -269,7 +240,7 @@ export async function VisaSummary({
             {shouldExtendVisa && (
               <p className="text-xs text-muted-foreground">
                 {t('extendVisaOnDate', {
-                  date: displayUKDateTime(subDays(visaExpiryDate, 28)),
+                  date: displayUKDateTime(extendVisaByDate),
                 })}
               </p>
             )}
@@ -288,9 +259,7 @@ export async function VisaSummary({
               {t('totalVisaDuration')}
             </span>
             <span className="font-medium">
-              {t('countDays', {
-                count: Math.ceil(totalVisaDuration / (1000 * 60 * 60 * 24)),
-              })}
+              {t('countDays', { count: totalVisaDurationDays })}
             </span>
           </div>
           <div className="flex justify-between items-center">
@@ -298,15 +267,7 @@ export async function VisaSummary({
               {t('daysSinceArrival')}
             </span>
             <span className="font-medium">
-              {t('countDays', {
-                count: Math.max(
-                  0,
-                  Math.ceil(
-                    (today.getTime() - arrivalDate.getTime()) /
-                      (1000 * 60 * 60 * 24)
-                  )
-                ),
-              })}
+              {t('countDays', { count: daysSinceArrival })}
             </span>
           </div>
           <div className="flex justify-between items-center">

--- a/lib/visa.ts
+++ b/lib/visa.ts
@@ -1,2 +1,79 @@
+import { addYears, differenceInYears, subDays } from 'date-fns';
+
 export const YEARS_TO_ILR = 5;
 export const YEARS_TO_CITIZENSHIP = 1;
+
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+const QUALIFYING_PERIOD_DAYS = (YEARS_TO_ILR + YEARS_TO_CITIZENSHIP) * 365;
+const EXTEND_VISA_BEFORE_EXPIRY_DAYS = 28;
+const EXPIRING_SOON_THRESHOLD_DAYS = 30;
+
+export interface VisaTimeline {
+  visaStartDate: Date;
+  visaExpiryDate: Date;
+  arrivalDate: Date;
+}
+
+export interface VisaStatus {
+  applyILRDate: Date;
+  applyCitizenshipDate: Date;
+  extendVisaByDate: Date;
+  totalVisaDurationDays: number;
+  daysSinceArrival: number;
+  daysUntilExpiry: number;
+  isExpired: boolean;
+  isExpiringSoon: boolean;
+  shouldExtendVisa: boolean;
+  progressPercentage: number;
+  visaExpiryPercentage: number;
+  ilrPercentage: number;
+}
+
+function clampPercentage(value: number): number {
+  return Math.round(Math.max(0, Math.min(100, value)));
+}
+
+export function getVisaStatus(
+  { visaStartDate, visaExpiryDate, arrivalDate }: VisaTimeline,
+  today: Date = new Date()
+): VisaStatus {
+  const applyILRDate = addYears(arrivalDate, YEARS_TO_ILR);
+  const applyCitizenshipDate = addYears(applyILRDate, YEARS_TO_CITIZENSHIP);
+
+  const daysSinceArrival = Math.max(
+    0,
+    Math.ceil((today.getTime() - arrivalDate.getTime()) / MS_PER_DAY)
+  );
+  const daysUntilExpiry = Math.ceil(
+    (visaExpiryDate.getTime() - today.getTime()) / MS_PER_DAY
+  );
+  const arrivalUntilExpiry = Math.ceil(
+    (visaExpiryDate.getTime() - arrivalDate.getTime()) / MS_PER_DAY
+  );
+  const daysStayed = (today.getTime() - arrivalDate.getTime()) / MS_PER_DAY;
+
+  return {
+    applyILRDate,
+    applyCitizenshipDate,
+    extendVisaByDate: subDays(visaExpiryDate, EXTEND_VISA_BEFORE_EXPIRY_DAYS),
+    totalVisaDurationDays: Math.ceil(
+      (visaExpiryDate.getTime() - visaStartDate.getTime()) / MS_PER_DAY
+    ),
+    daysSinceArrival,
+    daysUntilExpiry,
+    isExpired: daysUntilExpiry <= 0,
+    isExpiringSoon:
+      daysUntilExpiry <= EXPIRING_SOON_THRESHOLD_DAYS && daysUntilExpiry > 0,
+    shouldExtendVisa:
+      differenceInYears(visaExpiryDate, arrivalDate) < YEARS_TO_ILR,
+    progressPercentage: clampPercentage(
+      (daysStayed / QUALIFYING_PERIOD_DAYS) * 100
+    ),
+    visaExpiryPercentage: clampPercentage(
+      (arrivalUntilExpiry / QUALIFYING_PERIOD_DAYS) * 100
+    ),
+    ilrPercentage: clampPercentage(
+      (YEARS_TO_ILR / (YEARS_TO_ILR + YEARS_TO_CITIZENSHIP)) * 100
+    ),
+  };
+}

--- a/tests/units/lib/visa.test.ts
+++ b/tests/units/lib/visa.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  YEARS_TO_CITIZENSHIP,
+  YEARS_TO_ILR,
+  getVisaStatus,
+} from '@/lib/visa';
+
+const visaStartDate = new Date(2020, 0, 1);
+const arrivalDate = new Date(2020, 0, 1);
+const visaExpiryDate = new Date(2025, 0, 1);
+const today = new Date(2022, 0, 1);
+
+describe('getVisaStatus', () => {
+  it('computes the ILR and citizenship application dates from arrival', () => {
+    const status = getVisaStatus(
+      { visaStartDate, visaExpiryDate, arrivalDate },
+      today
+    );
+
+    expect(status.applyILRDate).toEqual(new Date(2025, 0, 1));
+    expect(status.applyCitizenshipDate).toEqual(new Date(2026, 0, 1));
+  });
+
+  it('computes the extend-by date as 28 days before expiry', () => {
+    const status = getVisaStatus(
+      { visaStartDate, visaExpiryDate, arrivalDate },
+      today
+    );
+
+    expect(status.extendVisaByDate).toEqual(new Date(2024, 11, 4));
+  });
+
+  describe('shouldExtendVisa', () => {
+    it('is true when the visa is granted for less than 5 years from arrival', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2024, 11, 31),
+        },
+        today
+      );
+
+      expect(status.shouldExtendVisa).toBe(true);
+    });
+
+    it('is false when the visa already covers a full 5 years from arrival', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2025, 0, 1),
+        },
+        today
+      );
+
+      expect(status.shouldExtendVisa).toBe(false);
+    });
+  });
+
+  describe('isExpired / isExpiringSoon', () => {
+    it('flags the visa as expired once expiry is today', () => {
+      const status = getVisaStatus(
+        { visaStartDate, arrivalDate, visaExpiryDate: today },
+        today
+      );
+
+      expect(status.isExpired).toBe(true);
+      expect(status.isExpiringSoon).toBe(false);
+    });
+
+    it('flags the visa as expired once expiry is in the past', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2021, 11, 31),
+        },
+        today
+      );
+
+      expect(status.isExpired).toBe(true);
+      expect(status.isExpiringSoon).toBe(false);
+    });
+
+    it('flags the visa as expiring soon when expiry is within 30 days', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2022, 0, 31),
+        },
+        today
+      );
+
+      expect(status.isExpired).toBe(false);
+      expect(status.isExpiringSoon).toBe(true);
+    });
+
+    it('does not flag the visa as expiring soon when expiry is more than 30 days away', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2022, 1, 1),
+        },
+        today
+      );
+
+      expect(status.isExpired).toBe(false);
+      expect(status.isExpiringSoon).toBe(false);
+    });
+  });
+
+  describe('progressPercentage', () => {
+    it('clamps to 0 when arrival is in the future', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          visaExpiryDate,
+          arrivalDate: new Date(2023, 0, 1),
+        },
+        today
+      );
+
+      expect(status.progressPercentage).toBe(0);
+    });
+
+    it('clamps to 100 once the full qualifying period has elapsed', () => {
+      const status = getVisaStatus(
+        { visaStartDate, visaExpiryDate, arrivalDate },
+        new Date(2030, 0, 1)
+      );
+
+      expect(status.progressPercentage).toBe(100);
+    });
+  });
+
+  describe('visaExpiryPercentage', () => {
+    it('clamps to 100 when the visa duration exceeds the qualifying period', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          arrivalDate,
+          visaExpiryDate: new Date(2030, 0, 1),
+        },
+        today
+      );
+
+      expect(status.visaExpiryPercentage).toBe(100);
+    });
+  });
+
+  it('reports a constant ILR percentage derived from the qualifying years', () => {
+    const status = getVisaStatus(
+      { visaStartDate, visaExpiryDate, arrivalDate },
+      today
+    );
+
+    expect(status.ilrPercentage).toBe(
+      Math.round((YEARS_TO_ILR / (YEARS_TO_ILR + YEARS_TO_CITIZENSHIP)) * 100)
+    );
+  });
+
+  describe('daysSinceArrival', () => {
+    it('floors at 0 when arrival is in the future', () => {
+      const status = getVisaStatus(
+        {
+          visaStartDate,
+          visaExpiryDate,
+          arrivalDate: new Date(2023, 0, 1),
+        },
+        today
+      );
+
+      expect(status.daysSinceArrival).toBe(0);
+    });
+
+    it('counts whole days elapsed since arrival', () => {
+      const status = getVisaStatus(
+        { visaStartDate, visaExpiryDate, arrivalDate },
+        new Date(2020, 0, 11)
+      );
+
+      expect(status.daysSinceArrival).toBe(10);
+    });
+  });
+
+  it('computes the total visa duration in days', () => {
+    const status = getVisaStatus(
+      {
+        visaStartDate: new Date(2020, 0, 1),
+        visaExpiryDate: new Date(2020, 0, 11),
+        arrivalDate,
+      },
+      today
+    );
+
+    expect(status.totalVisaDurationDays).toBe(10);
+  });
+});


### PR DESCRIPTION
The ILR/citizenship date math, expiry checks, and progress percentages
lived inline in the VisaSummary server component with zero test
coverage. Pulled it into a pure getVisaStatus function with unit tests
covering the boundary cases (5-year cutoff, expiry today/past/soon,
percentage clamping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralised visa timeline/status logic for more consistent eligibility dates and summary metrics.
  * Visa summary timeline now shows the citizenship application date; extension messaging uses the computed “extend by” date.
  * Totals (duration, days since arrival) and progress/expiry percentages are now derived consistently, with clamping for edge cases.
* **Tests**
  * Added unit tests covering visa status calculations and edge conditions.
* **Chores**
  * CI reliability improvements: Node 22, workflow/action updates, caching, and retry-based database setup/migrations; added branch-scoped concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->