### PR TITLE
Add component tests for form validation logic

### DIFF
--- a/tests/units/components/change-password-form.test.tsx
+++ b/tests/units/components/change-password-form.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChangePasswordForm } from '@/app/_components/change-password-form';
+import { userActions } from '@/app/actions';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  userActions: { changePassword: vi.fn() },
+}));
+
+it('renders all three password fields and a submit button', () => {
+  render(<ChangePasswordForm />);
+
+  expect(screen.getByLabelText('currentPassword')).toBeInTheDocument();
+  expect(screen.getByLabelText('newPassword')).toBeInTheDocument();
+  expect(screen.getByLabelText('confirmPassword')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
+});
+
+it('shows pleaseInput under each field when submitted empty', async () => {
+  render(<ChangePasswordForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+  expect(await screen.findAllByText('pleaseInput')).toHaveLength(3);
+});
+
+it('shows passwordNotMatched under confirmPassword when passwords differ', async () => {
+  render(<ChangePasswordForm />);
+
+  await userEvent.type(screen.getByLabelText('currentPassword'), 'current123');
+  await userEvent.type(screen.getByLabelText('newPassword'), 'new123');
+  await userEvent.type(
+    screen.getByLabelText('confirmPassword'),
+    'different456'
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+  expect(await screen.findByText('passwordNotMatched')).toBeInTheDocument();
+  expect(screen.queryByText('pleaseInput')).not.toBeInTheDocument();
+});
+
+describe('on valid submission', () => {
+  it('calls userActions.changePassword with the form data and shows a success toast', async () => {
+    vi.mocked(userActions.changePassword).mockResolvedValue({
+      result: { id: 'user-1', email: 'test@test.com' },
+    });
+    render(<ChangePasswordForm />);
+
+    await userEvent.type(
+      screen.getByLabelText('currentPassword'),
+      'current123'
+    );
+    await userEvent.type(screen.getByLabelText('newPassword'), 'new123');
+    await userEvent.type(screen.getByLabelText('confirmPassword'), 'new123');
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => {
+      expect(userActions.changePassword).toHaveBeenCalledTimes(1);
+    });
+    const formData = vi.mocked(userActions.changePassword).mock.calls[0][0];
+    expect(formData.get('currentPassword')).toBe('current123');
+    expect(formData.get('newPassword')).toBe('new123');
+    expect(formData.get('confirmPassword')).toBe('new123');
+    expect(toast.success).toHaveBeenCalledWith('success');
+  });
+
+  it('shows an error toast when the action returns an error', async () => {
+    vi.mocked(userActions.changePassword).mockResolvedValue({
+      error: 'Incorrect current password',
+    });
+    render(<ChangePasswordForm />);
+
+    await userEvent.type(screen.getByLabelText('currentPassword'), 'wrong');
+    await userEvent.type(screen.getByLabelText('newPassword'), 'new123');
+    await userEvent.type(screen.getByLabelText('confirmPassword'), 'new123');
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Incorrect current password');
+    });
+  });
+});

--- a/tests/units/components/leave-form.test.tsx
+++ b/tests/units/components/leave-form.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LeaveForm } from '@/app/_components/leave-form';
+import { leaveActions } from '@/app/actions';
+import { useRouter } from '@/i18n/navigation';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  leaveActions: { createLeave: vi.fn(), updateLeave: vi.fn() },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  useRouter: vi.fn(),
+}));
+
+vi.mock('@/app/_components/date-picker', () => ({
+  DatePicker: ({
+    value,
+    onChange,
+    ...props
+  }: {
+    value?: Date;
+    onChange: (d: Date | undefined) => void;
+  }) => (
+    <input
+      type="text"
+      value={value ? value.toISOString() : ''}
+      onChange={(e) =>
+        onChange(e.target.value ? new Date(e.target.value) : undefined)
+      }
+      {...props}
+    />
+  ),
+}));
+
+vi.mock('@/app/_components/color-picker', () => ({
+  GradientPicker: ({
+    background,
+    setBackground,
+    ...props
+  }: {
+    background?: string;
+    setBackground: (c: string) => void;
+  }) => (
+    <input
+      type="text"
+      value={background ?? ''}
+      onChange={(e) => setBackground(e.target.value)}
+      {...props}
+    />
+  ),
+}));
+
+function mockRouter() {
+  const push = vi.fn();
+  vi.mocked(useRouter).mockReturnValue({
+    push,
+  } as unknown as ReturnType<typeof useRouter>);
+  return push;
+}
+
+const fakeLeaveResult = {
+  id: 1,
+  createdAt: new Date('2025-01-01T00:00:00.000Z'),
+  startDate: new Date('2025-06-01T00:00:00.000Z'),
+  endDate: new Date('2025-06-10T00:00:00.000Z'),
+  color: '#123212',
+  remarks: null,
+  userId: 'user-1',
+};
+
+// The mocked DatePicker's onChange parses its full input value as a Date on
+// every change event. Setting the value in one shot (rather than simulating
+// keystroke-by-keystroke typing) avoids feeding it invalid partial strings.
+function setDateInput(label: string, isoString: string) {
+  fireEvent.change(screen.getByLabelText(label), {
+    target: { value: isoString },
+  });
+}
+
+it('renders the date, color, remarks fields and a submit button', () => {
+  mockRouter();
+  render(<LeaveForm />);
+
+  expect(screen.getByLabelText('startDate')).toBeInTheDocument();
+  expect(screen.getByLabelText('endDate')).toBeInTheDocument();
+  expect(screen.getByLabelText('color')).toBeInTheDocument();
+  expect(screen.getByLabelText('remarks')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
+});
+
+it('shows both date-required errors when submitted with no dates set', async () => {
+  mockRouter();
+  render(<LeaveForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+  expect(
+    await screen.findByText('startDateRequiredWarning')
+  ).toBeInTheDocument();
+  expect(screen.getByText('endDateRequiredWarning')).toBeInTheDocument();
+});
+
+it('shows wrongDateRange when endDate is before startDate', async () => {
+  mockRouter();
+  render(<LeaveForm />);
+
+  setDateInput('startDate', '2025-06-10T00:00:00.000Z');
+  setDateInput('endDate', '2025-06-01T00:00:00.000Z');
+  await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+  expect(await screen.findByText('wrongDateRange')).toBeInTheDocument();
+  expect(
+    screen.queryByText('startDateRequiredWarning')
+  ).not.toBeInTheDocument();
+});
+
+describe('create mode (no leave prop)', () => {
+  it('calls leaveActions.createLeave and navigates on success', async () => {
+    vi.mocked(leaveActions.createLeave).mockResolvedValue({
+      result: fakeLeaveResult,
+    });
+    const push = mockRouter();
+    render(<LeaveForm />);
+
+    setDateInput('startDate', '2025-06-01T00:00:00.000Z');
+    setDateInput('endDate', '2025-06-10T00:00:00.000Z');
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => {
+      expect(leaveActions.createLeave).toHaveBeenCalledTimes(1);
+    });
+    const formData = vi.mocked(leaveActions.createLeave).mock.calls[0][0];
+    expect(formData.get('id')).toBeNull();
+    expect(toast.success).toHaveBeenCalledWith('success');
+    expect(push).toHaveBeenCalledWith('/leaves');
+  });
+
+  it('shows an error toast when the action returns an error', async () => {
+    vi.mocked(leaveActions.createLeave).mockResolvedValue({
+      error: 'Something went wrong',
+    });
+    mockRouter();
+    render(<LeaveForm />);
+
+    setDateInput('startDate', '2025-06-01T00:00:00.000Z');
+    setDateInput('endDate', '2025-06-10T00:00:00.000Z');
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+});
+
+describe('edit mode (leave prop provided)', () => {
+  it('calls leaveActions.updateLeave with the leave id', async () => {
+    vi.mocked(leaveActions.updateLeave).mockResolvedValue({
+      result: fakeLeaveResult,
+    });
+    mockRouter();
+    render(
+      <LeaveForm
+        leave={{
+          id: 42,
+          startDate: new Date('2025-06-01T00:00:00.000Z'),
+          endDate: new Date('2025-06-10T00:00:00.000Z'),
+          color: '#abcdef',
+          remarks: 'existing remark',
+        }}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'submit' }));
+
+    await waitFor(() => {
+      expect(leaveActions.updateLeave).toHaveBeenCalledTimes(1);
+    });
+    const formData = vi.mocked(leaveActions.updateLeave).mock.calls[0][0];
+    expect(formData.get('id')).toBe('42');
+    expect(leaveActions.createLeave).not.toHaveBeenCalled();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     pool: 'threads', // Use threads to ensure isolation
     maxWorkers: 1, // Run tests in a single worker
+    clearMocks: true, // Reset vi.fn() call history between tests in the same file
     setupFiles: ['./tests/setup.ts', './tests/setup-rtl.ts'],
     coverage: {
       provider: 'istanbul',


### PR DESCRIPTION
## Summary
- Adds RTL component tests for `change-password-form.tsx` and `leave-form.tsx` — the only two form components with actual zod schemas (including cross-field `.refine()` checks). `sign-in-form`/`sign-up-form` were considered but turned out to rely on nothing beyond native HTML5 `required`/`type="email"`, so there's no validation logic there worth a dedicated test beyond what `sign-in.cy.ts`/`sign-up.cy.ts` already cover.
- `leave-form`'s `DatePicker`/`GradientPicker` subcomponents are mocked with minimal controlled inputs (forwarding `id`/`aria-*` so shadcn's `FormControl` label association still works). Driving two live Radix-popover calendars to pick specific dates is fragile and out of scope for a test about the form's own validation wiring, not the calendar widget's UI.
- Adds `clearMocks: true` to `vitest.config.ts`: `vi.mock()` factories create their mock functions once per file, so call counts were accumulating across tests in the same file — caught by a `not.toHaveBeenCalled()` assertion failing in `leave-form`'s edit-mode test, since an earlier create-mode test had already called the mock. Doesn't affect the existing DI-container-based tests, which don't use `vi.fn()` at all.

## Test plan
- [x] `yarn lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `yarn vitest run tests/units/components/` — 16/16 passing (5 ThemePicker + 5 change-password-form + 6 leave-form)
- [x] `yarn test` (full suite) — 104/104 passing, confirms `clearMocks` doesn't affect existing tests
- [x] `yarn coverage` — runs cleanly, instruments the new files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for password change and leave request workflows
  * Updated testing configuration to improve test reliability and isolation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->