### PR TITLE
Fix typo in endDateRequiredWarning message

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -17,7 +17,7 @@
   "startDateRequiredWarning": "Start date is required",
   "endDate": "End Date",
   "endDateDescription": "The date you came back",
-  "endDateRequiredWarning": "End date is requried",
+  "endDateRequiredWarning": "End date is required",
   "color": "Color",
   "colorFormatWarning": "The color should be in hex",
   "remarks": "Remarks",


### PR DESCRIPTION
## Summary
- `messages/en.json`'s `endDateRequiredWarning` said "End date is **requried**" — fixed to "required". `zh-Hant-HK`'s translation was already correct, unaffected.

## Test plan
- [x] `yarn lint` — clean
- [x] `yarn vitest run tests/units/components/leave-form.test.tsx` — still 6/6 (asserts on the translation key, not the string value, so unaffected by this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Corrected spelling error in the end date required warning message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->