### PR TITLE
Add component tests for LeaveDeleteButton, LocalePicker, UserAvatar

### DIFF
--- a/tests/units/components/leave-delete-button.test.tsx
+++ b/tests/units/components/leave-delete-button.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LeaveDeleteButton } from '@/app/_components/leave-delete-button';
+import { leaveActions } from '@/app/actions';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  leaveActions: { deleteLeave: vi.fn() },
+}));
+
+const startDate = new Date('2025-06-01T00:00:00.000Z');
+const endDate = new Date('2025-06-10T00:00:00.000Z');
+
+it('renders the trigger button', () => {
+  render(<LeaveDeleteButton id={1} startDate={startDate} endDate={endDate} />);
+
+  expect(screen.getByRole('button')).toBeInTheDocument();
+});
+
+it('opens a confirmation dialog showing the date range on click', async () => {
+  render(<LeaveDeleteButton id={1} startDate={startDate} endDate={endDate} />);
+
+  await userEvent.click(screen.getByRole('button'));
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(screen.getByText('deleteLeave')).toBeInTheDocument();
+  expect(screen.getByText('deleteReminder')).toBeInTheDocument();
+  expect(
+    screen.getByText('June 1st, 2025 - June 10th, 2025')
+  ).toBeInTheDocument();
+});
+
+describe('on confirm', () => {
+  it('calls leaveActions.deleteLeave with the id and shows a success toast', async () => {
+    vi.mocked(leaveActions.deleteLeave).mockResolvedValue({ success: 'ok' });
+    render(
+      <LeaveDeleteButton id={7} startDate={startDate} endDate={endDate} />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => {
+      expect(leaveActions.deleteLeave).toHaveBeenCalledWith(7);
+    });
+    expect(toast.success).toHaveBeenCalledWith('success');
+  });
+
+  it('shows an error toast when the action returns an error', async () => {
+    vi.mocked(leaveActions.deleteLeave).mockResolvedValue({
+      error: 'Something went wrong',
+    });
+    render(
+      <LeaveDeleteButton id={7} startDate={startDate} endDate={endDate} />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    await userEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Something went wrong');
+    });
+  });
+});

--- a/tests/units/components/locale-picker.test.tsx
+++ b/tests/units/components/locale-picker.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useLocale } from 'next-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import { LocalePicker } from '@/app/_components/locale-picker';
+import { usePathname, useRouter } from '@/i18n/navigation';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: vi.fn(),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  usePathname: vi.fn(),
+  useRouter: vi.fn(),
+}));
+
+function mockNavigation(locale: string) {
+  vi.mocked(useLocale).mockReturnValue(locale);
+  vi.mocked(usePathname).mockReturnValue('/leaves');
+  const replace = vi.fn();
+  vi.mocked(useRouter).mockReturnValue({
+    replace,
+  } as unknown as ReturnType<typeof useRouter>);
+  return replace;
+}
+
+it('renders the trigger button', () => {
+  mockNavigation('en');
+  render(<LocalePicker />);
+
+  expect(screen.getByRole('button')).toBeInTheDocument();
+});
+
+it('shows both locale options with translated labels', async () => {
+  mockNavigation('en');
+  render(<LocalePicker />);
+
+  await userEvent.click(screen.getByRole('button'));
+
+  expect(
+    screen.getByRole('menuitemradio', { name: 'english' })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('menuitemradio', { name: 'traditionalChinese' })
+  ).toBeInTheDocument();
+});
+
+it('calls router.replace with the new locale when an option is clicked', async () => {
+  const replace = mockNavigation('en');
+  render(<LocalePicker />);
+
+  await userEvent.click(screen.getByRole('button'));
+  await userEvent.click(
+    screen.getByRole('menuitemradio', { name: 'traditionalChinese' })
+  );
+
+  expect(replace).toHaveBeenCalledWith('/leaves', { locale: 'zh-Hant-HK' });
+});
+
+describe('active locale reflects the current value', () => {
+  it('marks the current locale as checked and the other as unchecked', async () => {
+    mockNavigation('zh-Hant-HK');
+    render(<LocalePicker />);
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(
+      screen.getByRole('menuitemradio', { name: 'traditionalChinese' })
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemradio', { name: 'english' })
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+});

--- a/tests/units/components/user-avatar.test.tsx
+++ b/tests/units/components/user-avatar.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UserAvatar } from '@/app/_components/user-avatar';
+import { authActions } from '@/app/actions';
+import useUser from '@/hooks/use-user';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('@/app/actions', () => ({
+  authActions: { signOut: vi.fn() },
+}));
+
+vi.mock('@/hooks/use-user', () => ({
+  default: vi.fn(),
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+it('renders the avatar trigger with the first letter of the user email', () => {
+  vi.mocked(useUser).mockReturnValue({ email: 'jane@test.com' });
+  render(<UserAvatar />);
+
+  expect(screen.getByRole('button', { name: 'user' })).toHaveTextContent('J');
+});
+
+it('shows settings and sign out options when opened', async () => {
+  vi.mocked(useUser).mockReturnValue({ email: 'jane@test.com' });
+  render(<UserAvatar />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'user' }));
+
+  expect(screen.getByRole('link', { name: 'settings' })).toHaveAttribute(
+    'href',
+    expect.stringContaining('/users/settings')
+  );
+  expect(screen.getByRole('menuitem', { name: 'signOut' })).toBeInTheDocument();
+});
+
+describe('on sign out', () => {
+  it('calls authActions.signOut when clicked', async () => {
+    vi.mocked(useUser).mockReturnValue({ email: 'jane@test.com' });
+    render(<UserAvatar />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'user' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'signOut' }));
+
+    await waitFor(() => {
+      expect(authActions.signOut).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Extends RTL component test coverage to three more interactive components, following the established pattern from the `ThemePicker`/`change-password-form`/`leave-form` tests:
- **LeaveDeleteButton**: confirmation dialog open, date-range display, confirm → `leaveActions.deleteLeave` call, success/error toast.
- **LocalePicker**: dropdown options render, active-locale `aria-checked` state, `router.replace` call with the new locale.
- **UserAvatar**: avatar trigger shows the user's email initial, settings link, `authActions.signOut` call on sign out. Mocks `@/hooks/use-user` directly rather than the underlying `userActions.getSelfUser` call, since the test's focus is the component's own rendering/interaction, not the hook's data fetching.

One real query-structure finding while writing the UserAvatar test: the settings menu item's `href` lives on the wrapping `<a>` (from `@/i18n/navigation`'s `Link`), not the inner `menuitem`-role div — `getByRole('link', ...)` is needed to check it, not `getByRole('menuitem', ...)`.

## Test plan
- [x] `yarn lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `yarn vitest run tests/units/components/` — 27/27 passing (6 files)
- [x] `yarn test` (full suite) — 115/115 passing