### PR TITLE
Extend Lighthouse CI to authenticated pages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,9 +127,11 @@ jobs:
           retention-days: 7
 
   # Job for Lighthouse CI performance/accessibility/best-practices/SEO budgets.
-  # Only scans the public sign-in/sign-up pages, so it needs no database
-  # setup at all -- the app falls back to a local sqlite file when
-  # DATABASE_URL isn't set, and those pages don't query the database.
+  # Scans the public sign-in/sign-up pages (no auth needed) plus the
+  # dashboard/leaves/settings pages, which lighthouse-auth-script.js signs
+  # into freshly via Puppeteer before each authenticated audit. The local
+  # sqlite fallback (no DATABASE_URL) needs its schema migrated first so
+  # those sign-ups actually have a users/user_settings table to write to.
   lighthouse:
     runs-on: ubuntu-latest
     needs: lint
@@ -150,10 +152,16 @@ jobs:
       - name: Install dependencies
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         run: yarn install --frozen-lockfile
+      - name: Run database migrations
+        run: yarn db:migrate
+        env:
+          NODE_ENV: test
       - name: Build Next.js project
         run: yarn build
-      - name: Run Lighthouse CI
+      - name: Run Lighthouse CI (public pages)
         run: npx lhci autorun
+      - name: Run Lighthouse CI (authenticated pages)
+        run: npx lhci autorun --config=lighthouserc.authenticated.js
       - name: Upload Lighthouse reports
         if: always()
         uses: actions/upload-artifact@v7

--- a/lighthouse-auth-script.js
+++ b/lighthouse-auth-script.js
@@ -1,0 +1,23 @@
+// Puppeteer setup script for LHCI: signs up a fresh, unique user before
+// each authenticated-page audit, since the app's session cookie is the
+// only way in (no header-based auth). LHCI hands us the shared `Browser`
+// (not a `Page`) and reuses its cookies for the page it then audits.
+module.exports = async (browser) => {
+  const email = `lhci-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
+  const password = 'lighthouse-ci-password';
+
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000/en/sign-up', {
+    waitUntil: 'networkidle0',
+  });
+  await page.waitForSelector('[data-cy=email]');
+  await page.type('[data-cy=email]', email);
+  await page.type('[data-cy=password]', password);
+  await page.type('[data-cy=confirmPassword]', password);
+  await page.click('[data-cy=submit]');
+
+  await page.waitForSelector('[data-cy=dashboard-content]', {
+    timeout: 30000,
+  });
+  await page.close();
+};

--- a/lighthouserc.authenticated.js
+++ b/lighthouserc.authenticated.js
@@ -1,0 +1,35 @@
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        'http://localhost:3000/en',
+        'http://localhost:3000/en/leaves',
+        'http://localhost:3000/en/users/settings',
+      ],
+      startServerCommand: 'yarn start',
+      startServerReadyPattern: 'Ready in',
+      // One run per URL: each run signs up a brand-new account via
+      // lighthouse-auth-script.js, so repeating runs for a median score
+      // would mean repeating sign-up several times over for little
+      // benefit. Revisit if these audits turn out to be noisy.
+      numberOfRuns: 1,
+      puppeteerScript: './lighthouse-auth-script.js',
+      // chromeFlags is ignored once puppeteerScript launches its own
+      // browser -- LHCI warns to use puppeteerLaunchOptions.args instead.
+      puppeteerLaunchOptions: {
+        args: ['--no-sandbox', '--disable-dev-shm-usage'],
+      },
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['error', { minScore: 0.7 }],
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+        'categories:best-practices': ['error', { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: 'filesystem',
+      outputDir: './lighthouse-reports',
+    },
+  },
+};

--- a/lighthouserc.authenticated.js
+++ b/lighthouserc.authenticated.js
@@ -5,6 +5,7 @@
 // relies on. Resolve the path ourselves the same way chrome-launcher does,
 // so this config doesn't depend on `puppeteer` (vs. `puppeteer-core`)
 // being installed.
+// eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS config file, loaded directly by LHCI via require()
 const { Launcher } = require('chrome-launcher');
 const chromePath = Launcher.getInstallations()[0];
 

--- a/lighthouserc.authenticated.js
+++ b/lighthouserc.authenticated.js
@@ -1,3 +1,13 @@
+// LHCI resolves Chrome differently once `puppeteerScript` is set: it
+// tries `require('puppeteer').executablePath()` first, which throws when
+// only `puppeteer-core` is installed (no bundled browser), short-circuiting
+// the normal chrome-launcher auto-detection that the public-pages config
+// relies on. Resolve the path ourselves the same way chrome-launcher does,
+// so this config doesn't depend on `puppeteer` (vs. `puppeteer-core`)
+// being installed.
+const { Launcher } = require('chrome-launcher');
+const chromePath = Launcher.getInstallations()[0];
+
 module.exports = {
   ci: {
     collect: {
@@ -8,6 +18,7 @@ module.exports = {
       ],
       startServerCommand: 'yarn start',
       startServerReadyPattern: 'Ready in',
+      chromePath,
       // One run per URL: each run signs up a brand-new account via
       // lighthouse-auth-script.js, so repeating runs for a median score
       // would mean repeating sign-up several times over for little


### PR DESCRIPTION
## Summary
Closes the gap noted in the README's "Future Improvements" section: Lighthouse CI previously only audited the public sign-in/sign-up pages, leaving the dashboard/leaves/settings pages with no performance/accessibility/best-practices budget at all.

- New `lighthouserc.authenticated.js` config audits `/en`, `/en/leaves`, and `/en/users/settings`.
- New `lighthouse-auth-script.js` is an LHCI `puppeteerScript` hook: since this app only supports cookie-based session auth (no header auth to inject), it signs up a fresh, unique account through the real sign-up flow before each audit. LHCI hands the script a shared `Browser` (not a `Page` — confirmed by reading `puppeteer-manager.js` after an initial `page.goto is not a function` error), so the script opens its own page, signs up, waits for the dashboard, then closes it; the session cookie carries over to the page Lighthouse audits next.
- `lighthouse` job in `.github/workflows/test.yml` now runs `yarn db:migrate` (NODE_ENV=test) before building, so the local-sqlite fallback has a schema for those sign-ups to write to. A second `npx lhci autorun --config=lighthouserc.authenticated.js` step runs after the existing public-pages run.
- `numberOfRuns: 1` for the authenticated config (vs. 3 for public pages) — each run signs up a brand-new account, so repeating runs for a median score would mean repeating sign-up several times over for one data point's worth of benefit.
- Thresholds are based on real local runs, not guesses: performance 0.79–0.86, accessibility 1.0, best-practices 0.96 — set `performance` at 0.7 (matching the public-pages config) and `accessibility`/`best-practices` at 0.9, with comfortable margin either side.

## Test plan
- [x] Ran `npx lhci autorun --config=lighthouserc.authenticated.js` locally — all 3 authenticated pages pass.
- [x] Ran `npx lhci autorun` (public pages) locally — unaffected, still passes.
- [x] `yarn lint` — clean (only pre-existing unrelated warnings).
- [x] CI: verify the `lighthouse` job passes both LHCI steps with `gh pr checks`.