### PR TITLE
feat: add Vercel Web Analytics

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,4 +1,5 @@
 import '../globals.css';
+import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { setDefaultOptions } from 'date-fns';
 import { enGB, zhHK } from 'date-fns/locale';
@@ -63,6 +64,7 @@ export default async function RootLayout({
         </NextIntlClientProvider>
         <Toaster position="bottom-center" />
         <SpeedInsights />
+        <Analytics />
         <RegisterServiceWorker />
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-tooltip": "^1.2.4",
     "@sentry/nextjs": "^10.58.0",
     "@tanstack/react-query": "^5.75.1",
+    "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "bcrypt-ts": "^8.0.0",
     "class-variance-authority": "^0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,11 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
+"@vercel/analytics@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@vercel/analytics/-/analytics-2.0.1.tgz#d7d7bd37af7cfbeea95db5f132ae4889f4d26407"
+  integrity sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==
+
 "@vercel/speed-insights@^1.2.0":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.3.1.tgz#df8baeba65a1aaaf11adbd09d3fe7edc6b2a493a"


### PR DESCRIPTION
## Summary
- Adds `@vercel/analytics` and renders `<Analytics />` in the root layout, next to the existing `<SpeedInsights />`, to track pageview/traffic metrics on Vercel's free Hobby tier.

## Test plan
- [x] `yarn build` succeeds
- [x] `npx tsc --noEmit` passes with no errors
- [x] `eslint .` shows only pre-existing unrelated warnings
- [ ] Verify analytics events show up in the Vercel dashboard after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated analytics tracking into the application.

* **Chores**
  * Added analytics package dependency to support new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->