### PR TITLE
feat: add loading states for slow async actions

### DIFF
--- a/app/[locale]/(private)/loading.tsx
+++ b/app/[locale]/(private)/loading.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from '@/app/_components/ui/skeleton';
+
+export default function PrivateLoading() {
+  return (
+    <div
+      className="w-full max-w-3xl mx-auto flex flex-1 flex-col gap-4 p-4"
+      data-cy="private-loading"
+    >
+      <Skeleton className="h-8 w-1/3" />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  );
+}

--- a/app/_components/sign-in-form.tsx
+++ b/app/_components/sign-in-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Label } from '@radix-ui/react-label';
+import { Loader2 } from 'lucide-react';
 import { useLocale, useTranslations } from 'next-intl';
 import { useTransition } from 'react';
 import { toast } from 'sonner';
@@ -81,7 +82,13 @@ export function SignInForm({
                   required
                 />
               </div>
-              <Button type="submit" data-cy="submit" className="w-full">
+              <Button
+                type="submit"
+                data-cy="submit"
+                className="w-full"
+                disabled={loading}
+              >
+                {loading && <Loader2 className="animate-spin" />}
                 {t('signIn')}
               </Button>
             </div>

--- a/app/_components/sign-up-form.tsx
+++ b/app/_components/sign-up-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Label } from '@radix-ui/react-label';
+import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useTransition } from 'react';
 import { toast } from 'sonner';
@@ -88,7 +89,13 @@ export function SignUpForm({
                   required
                 />
               </div>
-              <Button type="submit" data-cy="submit" className="w-full">
+              <Button
+                type="submit"
+                data-cy="submit"
+                className="w-full"
+                disabled={loading}
+              >
+                {loading && <Loader2 className="animate-spin" />}
                 {t('signUp')}
               </Button>
             </div>

--- a/app/_components/user-avatar.tsx
+++ b/app/_components/user-avatar.tsx
@@ -1,5 +1,6 @@
-import { BadgeCheck, LogOut } from 'lucide-react';
+import { BadgeCheck, LogOut, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useTransition } from 'react';
 
 import { Avatar, AvatarFallback } from '@/app/_components/ui/avatar';
 import {
@@ -10,6 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/app/_components/ui/dropdown-menu';
+import { Skeleton } from '@/app/_components/ui/skeleton';
 import { authActions } from '@/app/actions';
 import useUser from '@/hooks/use-user';
 import { Link } from '@/i18n/navigation';
@@ -17,10 +19,20 @@ import { Link } from '@/i18n/navigation';
 export function UserAvatar() {
   const t = useTranslations();
   const user = useUser();
+  const [signingOut, startSignOut] = useTransition();
 
-  const onSignOut = async () => {
-    await authActions.signOut();
+  const onSignOut = () => {
+    if (signingOut) return;
+    startSignOut(async () => {
+      await authActions.signOut();
+    });
   };
+
+  if (user === undefined) {
+    return (
+      <Skeleton data-cy="avatar-skeleton" className="h-8 w-8 rounded-full" />
+    );
+  }
 
   const avatar = (
     <Avatar
@@ -54,8 +66,12 @@ export function UserAvatar() {
           </Link>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={onSignOut} data-cy="avatar-logout">
-          <LogOut />
+        <DropdownMenuItem
+          onClick={onSignOut}
+          data-cy="avatar-logout"
+          disabled={signingOut}
+        >
+          {signingOut ? <Loader2 className="animate-spin" /> : <LogOut />}
           {t('signOut')}
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary
- Wire up the existing `loading`/`useTransition` state on the sign-in and sign-up submit buttons (spinner + disabled), matching the pattern already used in `LeaveForm`.
- Show a spinner and disable the menu item while sign-out is in flight, instead of giving no feedback.
- Render a skeleton circle for the header avatar while the current user is still being fetched, instead of a blank fallback.
- Add `app/[locale]/(private)/loading.tsx` so private pages (dashboard, leaves, settings) show a skeleton instead of a blank screen during server-side navigation — no `loading.tsx` existed anywhere in the app before this.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `eslint` clean on changed files
- [x] `vitest run` — 115/115 tests passing
- [x] Dev server serves `/en/sign-in` and `/en/sign-up` with HTTP 200, no compile errors
- [ ] Manual click-through with throttled network to visually confirm spinners/skeletons (no browser automation tool available in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sign-in and sign-up forms now display loading spinners during authentication, with disabled buttons to prevent duplicate submissions.
  * Sign-out action now shows a loading spinner and prevents duplicate attempts whilst processing.
  * Added loading skeleton placeholders for improved visual feedback on private pages and when loading user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->