### PR TITLE
fix: refresh session cookie expiry on every authenticated request

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,2 +1,4 @@
 export const SESSION_COOKIE = 'auth_session';
 export const PASSWORD_SALT_ROUNDS = 10;
+export const SESSION_EXPIRY_MS = 1000 * 60 * 60 * 24 * 30;
+export const SESSION_RENEWAL_THRESHOLD_MS = 1000 * 60 * 60 * 24 * 15;

--- a/proxy.ts
+++ b/proxy.ts
@@ -34,7 +34,13 @@ export default async function proxy(request: NextRequest) {
     }
     try {
       const authenticationService = getInjection('IAuthenticationService');
-      await authenticationService.validateSession(sessionId);
+      const { session } =
+        await authenticationService.validateSession(sessionId);
+      const cookie = authenticationService.buildSessionCookie(
+        sessionId,
+        session.expiresAt
+      );
+      response.cookies.set(cookie.name, cookie.value, cookie.attributes);
     } catch {
       return NextResponse.redirect(
         new URL(`/${defaultLocale}/sign-in`, request.url)

--- a/src/application/services/authentication.service.interface.ts
+++ b/src/application/services/authentication.service.interface.ts
@@ -10,5 +10,6 @@ export interface IAuthenticationService {
     usersHashedPassword: string
   ): Promise<boolean>;
   createSession(user: User): Promise<{ session: Session; cookie: Cookie }>;
+  buildSessionCookie(token: string, expiresAt: Date): Cookie;
   invalidateSession(token: string): Promise<{ blankCookie: Cookie }>;
 }

--- a/src/infrastructure/services/authentication.service.ts
+++ b/src/infrastructure/services/authentication.service.ts
@@ -5,7 +5,11 @@ import {
 } from '@oslojs/encoding';
 import { compare } from 'bcrypt-ts';
 
-import { SESSION_COOKIE } from '@/config';
+import {
+  SESSION_COOKIE,
+  SESSION_EXPIRY_MS,
+  SESSION_RENEWAL_THRESHOLD_MS,
+} from '@/config';
 
 import { ISessionsRepository } from '@/src/application/repositories/sessions.repository.interface';
 import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
@@ -71,13 +75,15 @@ export class AuthenticationService implements IAuthenticationService {
           await this._sessionRepository.deleteSession(sessionId);
           throw new UnauthenticatedError('Session Expired');
         }
+
+        let session = result.session;
         if (
           Date.now() >=
-          result.session.expiresAt.getTime() - 1000 * 60 * 60 * 24 * 15
+          session.expiresAt.getTime() - SESSION_RENEWAL_THRESHOLD_MS
         ) {
-          await this._sessionRepository.updateSessionExpiresAt(
+          session = await this._sessionRepository.updateSessionExpiresAt(
             sessionId,
-            new Date(Date.now() + 1000 * 60 * 60 * 24 * 30)
+            new Date(Date.now() + SESSION_EXPIRY_MS)
           );
         }
 
@@ -85,7 +91,7 @@ export class AuthenticationService implements IAuthenticationService {
           throw new UnauthenticatedError("User doesn't exist");
         }
 
-        return { user: result.user, session: result.session };
+        return { user: result.user, session };
       }
     );
   }
@@ -104,29 +110,32 @@ export class AuthenticationService implements IAuthenticationService {
         const sessionId = encodeHexLowerCase(
           sha256(new TextEncoder().encode(token))
         );
-        // expires in 30 days
-        const expiresAt = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+        const expiresAt = new Date(Date.now() + SESSION_EXPIRY_MS);
         const session = await this._sessionRepository.createSession({
           id: sessionId,
           userId: user.id,
           expiresAt: expiresAt,
         });
 
-        const cookie: Cookie = {
-          name: SESSION_COOKIE,
-          value: token,
-          attributes: {
-            path: '/',
-            expires: expiresAt,
-            sameSite: 'lax',
-            httpOnly: true,
-            secure: process.env.NODE_ENV === 'production',
-          },
-        };
+        const cookie = this.buildSessionCookie(token, expiresAt);
 
         return { session, cookie };
       }
     );
+  }
+
+  buildSessionCookie(token: string, expiresAt: Date): Cookie {
+    return {
+      name: SESSION_COOKIE,
+      value: token,
+      attributes: {
+        path: '/',
+        expires: expiresAt,
+        sameSite: 'lax',
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+      },
+    };
   }
 
   async invalidateSession(token: string): Promise<{ blankCookie: Cookie }> {

--- a/tests/units/infrastructure/services/authentication.service.test.ts
+++ b/tests/units/infrastructure/services/authentication.service.test.ts
@@ -1,0 +1,68 @@
+import { sha256 } from '@oslojs/crypto/sha2';
+import { encodeHexLowerCase } from '@oslojs/encoding';
+import { expect, it } from 'vitest';
+
+import { SESSION_COOKIE, SESSION_RENEWAL_THRESHOLD_MS } from '@/config';
+import { getInjection } from '@/di/container';
+
+const authenticationService = getInjection('IAuthenticationService');
+const sessionsRepository = getInjection('ISessionRepository');
+
+function hashToken(token: string): string {
+  return encodeHexLowerCase(sha256(new TextEncoder().encode(token)));
+}
+
+it('renews the session and returns the renewed expiresAt when close to expiry', async () => {
+  const token = 'renew-token';
+  const almostExpired = new Date(
+    Date.now() + SESSION_RENEWAL_THRESHOLD_MS - 1000
+  );
+  await sessionsRepository.createSession({
+    id: hashToken(token),
+    userId: '1',
+    expiresAt: almostExpired,
+  });
+
+  const { session } = await authenticationService.validateSession(token);
+
+  expect(session.expiresAt.getTime()).toBeGreaterThan(
+    almostExpired.getTime()
+  );
+});
+
+it('keeps the original expiresAt when not close to expiry', async () => {
+  const token = 'no-renew-token';
+  // drizzle's sqlite timestamp mode stores seconds, so round to avoid
+  // a false mismatch from millisecond truncation on read-back
+  const farExpiry = new Date(
+    Math.floor((Date.now() + SESSION_RENEWAL_THRESHOLD_MS * 3) / 1000) * 1000
+  );
+  await sessionsRepository.createSession({
+    id: hashToken(token),
+    userId: '1',
+    expiresAt: farExpiry,
+  });
+
+  const { session } = await authenticationService.validateSession(token);
+
+  expect(session.expiresAt).toEqual(farExpiry);
+});
+
+it('builds a session cookie carrying the given token and expiry', () => {
+  const expiresAt = new Date(2030, 0, 1);
+  const cookie = authenticationService.buildSessionCookie(
+    'my-token',
+    expiresAt
+  );
+
+  expect(cookie).toMatchObject({
+    name: SESSION_COOKIE,
+    value: 'my-token',
+    attributes: {
+      path: '/',
+      expires: expiresAt,
+      sameSite: 'lax',
+      httpOnly: true,
+    },
+  });
+});


### PR DESCRIPTION
## Summary
- The sliding-window session renewal (extend by 30 days when within 15 days of expiry) only ever updated the **database** row's `expiresAt`. The browser's `auth_session` cookie was set once at sign-in with a fixed 30-day expiry and was never refreshed, so users were forced to log in again on that fixed schedule regardless of how active they were — even though the server considered the session still valid (or already renewed).
- Fixed a secondary bug where `validateSession` returned the **stale** pre-renewal session object instead of the renewed one.
- Extracted the cookie-construction logic into a reusable `buildSessionCookie(token, expiresAt)` on `IAuthenticationService`, used both by `createSession` (sign-in/sign-up) and now by the middleware.
- `proxy.ts` now re-sets the session cookie on every authenticated request using the current (possibly just-renewed) `expiresAt`, keeping the browser cookie in sync with the database session.
- Extracted the previously-inlined 30-day/15-day magic numbers into named constants in `config.ts`.

## Test plan
- [x] Added `tests/units/infrastructure/services/authentication.service.test.ts` — covers renewal returning the fresh expiry when near the threshold, no renewal when far from it, and `buildSessionCookie` output shape.
- [x] `vitest run` — 121/121 tests passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Manually confirmed via dev server that unauthenticated requests still correctly redirect to `/sign-in` (no regression)
- [ ] Manual click-through confirming the `auth_session` cookie's `Expires` value visibly advances on reload when near the renewal window (no browser automation tool available in this environment to verify directly)