### PR TITLE
feat: add /api/health endpoint

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+import { client } from '@/drizzle';
+import { getInjection } from '@/di/container';
+
+export async function GET() {
+  try {
+    await client.execute('select 1');
+    return NextResponse.json({ status: 'ok' });
+  } catch (error) {
+    const crashReporterService = getInjection('ICrashReporterService');
+    crashReporterService.report(error);
+    return NextResponse.json({ status: 'error' }, { status: 503 });
+  }
+}

--- a/tests/units/api/health/route.test.ts
+++ b/tests/units/api/health/route.test.ts
@@ -1,0 +1,10 @@
+import { expect, it } from 'vitest';
+
+import { GET } from '@/app/api/health/route';
+
+it('returns ok when the database is reachable', async () => {
+  const response = await GET();
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toEqual({ status: 'ok' });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/health`, a lightweight health check that pings the database (`select 1` via the existing drizzle/libsql `client`) and returns `200 {"status":"ok"}` if reachable, or `503 {"status":"error"}` (reported via the existing `ICrashReporterService`) if not.
- The route naturally bypasses the i18n/auth middleware since `proxy.ts`'s matcher already excludes `/api`.
- Useful for uptime monitors or load balancer readiness probes; the project previously had no health check endpoint at all.

## Test plan
- [x] Added `tests/units/api/health/route.test.ts` covering the happy path against the real test DB (consistent with this codebase's no-mocking test convention)
- [x] `vitest run` — 119/119 tests passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files
- [x] Manually verified via dev server: `curl /api/health` returns `200 {"status":"ok"}` with no auth redirect, while `/en` without a session cookie still correctly redirects to sign-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint providing system status and database connectivity verification.

* **Tests**
  * Added unit tests for the new health check endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->