### PR TITLE
feat: add bloom filter to accelerate email-taken check on sign-up

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -2,3 +2,5 @@ export const SESSION_COOKIE = 'auth_session';
 export const PASSWORD_SALT_ROUNDS = 10;
 export const SESSION_EXPIRY_MS = 1000 * 60 * 60 * 24 * 30;
 export const SESSION_RENEWAL_THRESHOLD_MS = 1000 * 60 * 60 * 24 * 15;
+export const BLOOM_FILTER_EXPECTED_EMAILS = 10000;
+export const BLOOM_FILTER_ERROR_RATE = 0.01;

--- a/di/modules/authentication.module.ts
+++ b/di/modules/authentication.module.ts
@@ -41,6 +41,7 @@ export function createAuthenticationModule() {
       DI_SYMBOLS.IAuthenticationService,
       DI_SYMBOLS.IUsersRepository,
       DI_SYMBOLS.IUserSettingsRepository,
+      DI_SYMBOLS.IEmailBloomFilterService,
     ]);
 
   authenticationModule

--- a/di/modules/users.module.ts
+++ b/di/modules/users.module.ts
@@ -5,6 +5,7 @@ import { getUserUseCase } from '@/src/application/use-cases/users/get-user.use-c
 import { updateUserEmailUseCase } from '@/src/application/use-cases/users/update-user-email.use-case';
 import { updateUserPasswordUseCase } from '@/src/application/use-cases/users/update-user-password.use-case';
 import { UsersRepository } from '@/src/infrastructure/repositories/users.repository';
+import { EmailBloomFilterService } from '@/src/infrastructure/services/email-bloom-filter.service';
 import { getSelfUserController } from '@/src/interface-adapters/controllers/users/get-self-user.controller';
 import { updateUserEmailController } from '@/src/interface-adapters/controllers/users/update-user-email.controller';
 import { updateUserPasswordController } from '@/src/interface-adapters/controllers/users/update-user-password.controller';
@@ -17,6 +18,13 @@ export function createUsersModule() {
     .toClass(UsersRepository, [
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.ICrashReporterService,
+    ]);
+
+  usersModule
+    .bind(DI_SYMBOLS.IEmailBloomFilterService)
+    .toClass(EmailBloomFilterService, [
+      DI_SYMBOLS.IUsersRepository,
+      DI_SYMBOLS.IInstrumentationService,
     ]);
 
   usersModule

--- a/di/types.ts
+++ b/di/types.ts
@@ -4,6 +4,7 @@ import { IUserSettingsRepository } from '@/src/application/repositories/user-set
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
 import { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
+import { IEmailBloomFilterService } from '@/src/application/services/email-bloom-filter.service.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
 import { ISignInUseCase } from '@/src/application/use-cases/auth/sign-in.use-case';
@@ -39,6 +40,7 @@ export const DI_SYMBOLS = {
   ITransactionManagerService: Symbol.for('ITransactionManagerService'),
   IInstrumentationService: Symbol.for('IInstrumentationService'),
   ICrashReporterService: Symbol.for('ICrashReporterService'),
+  IEmailBloomFilterService: Symbol.for('IEmailBloomFilterService'),
 
   // Repositories
   ILeavesRepository: Symbol.for('ILeavesRepository'),
@@ -85,6 +87,7 @@ export interface DI_RETURN_TYPES {
   ITransactionManagerService: ITransactionManagerService;
   IInstrumentationService: IInstrumentationService;
   ICrashReporterService: ICrashReporterService;
+  IEmailBloomFilterService: IEmailBloomFilterService;
 
   // Repositories
   ILeavesRepository: ILeavesRepository;

--- a/drizzle/migrations/0009_orange_black_tarantula.sql
+++ b/drizzle/migrations/0009_orange_black_tarantula.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);

--- a/drizzle/migrations/meta/0009_snapshot.json
+++ b/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,235 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5e188cda-de2c-4561-8ead-66939330d044",
+  "prevId": "8c8a5052-3d09-4145-96e2-3f1dfb178782",
+  "tables": {
+    "leaves": {
+      "name": "leaves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaves_user_id_users_id_fk": {
+          "name": "leaves_user_id_users_id_fk",
+          "tableFrom": "leaves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "visa_start_date": {
+          "name": "visa_start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visa_expiry_date": {
+          "name": "visa_expiry_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1749254556447,
       "tag": "0008_peaceful_slipstream",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1782305442322,
+      "tag": "0009_orange_black_tarantula",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -3,7 +3,7 @@ import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
 
 export const users = sqliteTable('users', {
   id: text('id').primaryKey().notNull(),
-  email: text('email').notNull(),
+  email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
 });
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "bcrypt-ts": "^8.0.0",
+    "bloom-filters": "^3.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/src/application/repositories/users.repository.interface.ts
+++ b/src/application/repositories/users.repository.interface.ts
@@ -4,6 +4,7 @@ import type { CreateUser, UpdateUser, User } from '@/src/entities/models/user';
 export interface IUsersRepository {
   getUser(id: string): Promise<User | undefined>;
   getUserByEmail(email: string): Promise<User | undefined>;
+  getAllEmails(): Promise<string[]>;
   createUser(input: CreateUser, tx?: ITransaction): Promise<User>;
   updateUser(
     id: string,

--- a/src/application/services/email-bloom-filter.service.interface.ts
+++ b/src/application/services/email-bloom-filter.service.interface.ts
@@ -1,0 +1,4 @@
+export interface IEmailBloomFilterService {
+  mightContainEmail(email: string): Promise<boolean>;
+  recordEmail(email: string): Promise<void>;
+}

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -1,8 +1,10 @@
 import { IUserSettingsRepository } from '@/src/application/repositories/user-settings.repository.interface';
 import type { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import type { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
+import type { IEmailBloomFilterService } from '@/src/application/services/email-bloom-filter.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { AuthenticationError } from '@/src/entities/errors/auth';
+import { ConflictError } from '@/src/entities/errors/common';
 import { Cookie } from '@/src/entities/models/cookie';
 import { Session } from '@/src/entities/models/session';
 import { User } from '@/src/entities/models/user';
@@ -14,7 +16,8 @@ export const signUpUseCase =
     instrumentationService: IInstrumentationService,
     authenticationService: IAuthenticationService,
     usersRepository: IUsersRepository,
-    userSettingsRepository: IUserSettingsRepository
+    userSettingsRepository: IUserSettingsRepository,
+    emailBloomFilterService: IEmailBloomFilterService
   ) =>
   (input: {
     email: string;
@@ -27,18 +30,32 @@ export const signUpUseCase =
     return instrumentationService.startSpan(
       { name: 'signUp Use Case', op: 'function' },
       async () => {
-        const existingUser = await usersRepository.getUserByEmail(input.email);
-        if (existingUser) {
-          throw new AuthenticationError('Email taken');
+        if (await emailBloomFilterService.mightContainEmail(input.email)) {
+          const existingUser = await usersRepository.getUserByEmail(
+            input.email
+          );
+          if (existingUser) {
+            throw new AuthenticationError('Email taken');
+          }
         }
 
         const userId = authenticationService.generateUserId();
 
-        const newUser = await usersRepository.createUser({
-          id: userId,
-          email: input.email,
-          password: input.password,
-        });
+        let newUser: User;
+        try {
+          newUser = await usersRepository.createUser({
+            id: userId,
+            email: input.email,
+            password: input.password,
+          });
+        } catch (err) {
+          if (err instanceof ConflictError) {
+            throw new AuthenticationError('Email taken');
+          }
+          throw err;
+        }
+
+        await emailBloomFilterService.recordEmail(input.email);
 
         await userSettingsRepository.createUserSettings(userId);
 

--- a/src/entities/errors/common.ts
+++ b/src/entities/errors/common.ts
@@ -15,3 +15,9 @@ export class InputParseError extends Error {
     super(message, options);
   }
 }
+
+export class ConflictError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}

--- a/src/infrastructure/repositories/users.repository.ts
+++ b/src/infrastructure/repositories/users.repository.ts
@@ -1,4 +1,5 @@
 import { Transaction, db } from '@/drizzle';
+import { LibsqlError } from '@libsql/client';
 import { hash } from 'bcrypt-ts';
 import { eq } from 'drizzle-orm';
 
@@ -8,7 +9,10 @@ import { users } from '@/drizzle/schema';
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
-import { DatabaseOperationError } from '@/src/entities/errors/common';
+import {
+  ConflictError,
+  DatabaseOperationError,
+} from '@/src/entities/errors/common';
 import type { CreateUser, UpdateUser, User } from '@/src/entities/models/user';
 
 export class UsersRepository implements IUsersRepository {
@@ -68,6 +72,31 @@ export class UsersRepository implements IUsersRepository {
       }
     );
   }
+  async getAllEmails(): Promise<string[]> {
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > getAllEmails' },
+      async () => {
+        try {
+          const query = db.select({ email: users.email }).from(users);
+
+          const rows = await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+
+          return rows.map((row) => row.email);
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // TODO: convert to Entities error
+        }
+      }
+    );
+  }
+
   async createUser(input: CreateUser): Promise<User> {
     return await this.instrumentationService.startSpan(
       { name: 'UsersRepository > createUser' },
@@ -100,6 +129,13 @@ export class UsersRepository implements IUsersRepository {
             throw new DatabaseOperationError('Cannot create user.');
           }
         } catch (err) {
+          const cause = err instanceof Error ? err.cause : undefined;
+          if (
+            cause instanceof LibsqlError &&
+            cause.code?.startsWith('SQLITE_CONSTRAINT')
+          ) {
+            throw new ConflictError('Email taken', { cause: err });
+          }
           this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
         }

--- a/src/infrastructure/services/email-bloom-filter.service.ts
+++ b/src/infrastructure/services/email-bloom-filter.service.ts
@@ -1,0 +1,46 @@
+import { BloomFilter } from 'bloom-filters';
+
+import {
+  BLOOM_FILTER_ERROR_RATE,
+  BLOOM_FILTER_EXPECTED_EMAILS,
+} from '@/config';
+
+import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import { IEmailBloomFilterService } from '@/src/application/services/email-bloom-filter.service.interface';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+
+export class EmailBloomFilterService implements IEmailBloomFilterService {
+  private readonly _filter = BloomFilter.create(
+    BLOOM_FILTER_EXPECTED_EMAILS,
+    BLOOM_FILTER_ERROR_RATE
+  );
+  private _warmupPromise: Promise<void> | undefined;
+
+  constructor(
+    private readonly _usersRepository: IUsersRepository,
+    private readonly _instrumentationService: IInstrumentationService
+  ) {}
+
+  private _warmup(): Promise<void> {
+    if (!this._warmupPromise) {
+      this._warmupPromise = this._instrumentationService.startSpan(
+        { name: 'EmailBloomFilterService > warmup' },
+        async () => {
+          const emails = await this._usersRepository.getAllEmails();
+          emails.forEach((email) => this._filter.add(email));
+        }
+      );
+    }
+    return this._warmupPromise;
+  }
+
+  async mightContainEmail(email: string): Promise<boolean> {
+    await this._warmup();
+    return this._filter.has(email);
+  }
+
+  async recordEmail(email: string): Promise<void> {
+    await this._warmup();
+    this._filter.add(email);
+  }
+}

--- a/tests/units/infrastructure/repositories/users.repository.test.ts
+++ b/tests/units/infrastructure/repositories/users.repository.test.ts
@@ -2,6 +2,7 @@ import { compare } from 'bcrypt-ts';
 import { expect, it } from 'vitest';
 
 import { getInjection } from '@/di/container';
+import { ConflictError } from '@/src/entities/errors/common';
 
 const usersRepository = getInjection('IUsersRepository');
 
@@ -78,4 +79,29 @@ it('should return undefined when getting a user with non-existent email', async 
   await expect(
     usersRepository.getUserByEmail('non-existent@test.com')
   ).resolves.toBeUndefined();
+});
+
+it('gets all emails', async () => {
+  await usersRepository.createUser({
+    id: '9',
+    email: 'nine@test.com',
+    password: 'password-nine',
+  });
+  const emails = await usersRepository.getAllEmails();
+  expect(emails).toContain('nine@test.com');
+});
+
+it('throws a ConflictError when creating a user with a duplicate email', async () => {
+  await usersRepository.createUser({
+    id: '10',
+    email: 'ten@test.com',
+    password: 'password-ten',
+  });
+  await expect(
+    usersRepository.createUser({
+      id: '11',
+      email: 'ten@test.com',
+      password: 'password-eleven',
+    })
+  ).rejects.toBeInstanceOf(ConflictError);
 });

--- a/tests/units/infrastructure/services/email-bloom-filter.service.test.ts
+++ b/tests/units/infrastructure/services/email-bloom-filter.service.test.ts
@@ -1,0 +1,26 @@
+import { expect, it } from 'vitest';
+
+import { getInjection } from '@/di/container';
+
+const emailBloomFilterService = getInjection('IEmailBloomFilterService');
+
+it('returns true for an email already in the database', async () => {
+  await expect(
+    emailBloomFilterService.mightContainEmail('one@test.com')
+  ).resolves.toBe(true);
+});
+
+it('returns false for an email that has never been seen', async () => {
+  await expect(
+    emailBloomFilterService.mightContainEmail(
+      'definitely-not-registered@test.com'
+    )
+  ).resolves.toBe(false);
+});
+
+it('returns true after recording a new email', async () => {
+  await emailBloomFilterService.recordEmail('freshly-recorded@test.com');
+  await expect(
+    emailBloomFilterService.mightContainEmail('freshly-recorded@test.com')
+  ).resolves.toBe(true);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,6 +2592,11 @@
   dependencies:
     csstype "^3.2.2"
 
+"@types/seedrandom@^3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-3.0.8.tgz#61cc8ed88f93a3c31289c295e6df8ca40be42bdf"
+  integrity sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==
+
 "@types/sinonjs__fake-timers@8.1.1":
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.1.tgz#b49c2c70150141a15e0fa7e79cf1f92a72934ce3"
@@ -3273,6 +3278,11 @@ bare-url@^2.2.2:
   dependencies:
     bare-path "^3.0.0"
 
+base64-arraybuffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
+  integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -3316,6 +3326,20 @@ blob-util@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/blob-util/-/blob-util-2.0.2.tgz#3b4e3c281111bb7f11128518006cdc60b403a1eb"
   integrity sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
+
+bloom-filters@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bloom-filters/-/bloom-filters-3.0.4.tgz#2712bd8f8092fd0a081fe52a17c63be79dbbfc1e"
+  integrity sha512-BdnPWo2OpYhlvuP2fRzJBdioMCkm7Zp0HCf8NJgF5Mbyqy7VQ/CnTiVWMMyq4EZCBHwj0Kq6098gW2/3RsZsrA==
+  dependencies:
+    "@types/seedrandom" "^3.0.8"
+    base64-arraybuffer "^1.0.2"
+    is-buffer "^2.0.5"
+    lodash "^4.17.21"
+    long "^5.2.0"
+    reflect-metadata "^0.1.13"
+    seedrandom "^3.0.5"
+    xxhashjs "^0.2.2"
 
 bluebird@^3.7.2:
   version "3.7.2"
@@ -3753,6 +3777,11 @@ csstype@^3.2.2:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.2.3.tgz#ec48c0f3e993e50648c86da559e2610995cf989a"
   integrity sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
+
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw==
 
 cypress-axe@^1.7.0:
   version "1.7.0"
@@ -5381,6 +5410,11 @@ is-boolean-object@^1.2.1:
     call-bound "^1.0.3"
     has-tostringtag "^1.0.2"
 
+is-buffer@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
+  integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
+
 is-bun-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-bun-module/-/is-bun-module-2.0.0.tgz#4d7859a87c0fcac950c95e666730e745eae8bddd"
@@ -6123,7 +6157,7 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.17.12, lodash@^4.17.23:
+lodash@^4.17.12, lodash@^4.17.21, lodash@^4.17.23:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -6146,6 +6180,11 @@ log-update@^6.1.0:
     slice-ansi "^7.1.0"
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
+
+long@^5.2.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.3.2.tgz#1d84463095999262d7d7b7f8bfd4a8cc55167f83"
+  integrity sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==
 
 lookup-closest-locale@6.2.0:
   version "6.2.0"
@@ -7039,6 +7078,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+reflect-metadata@^0.1.13:
+  version "0.1.14"
+  resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.14.tgz#24cf721fe60677146bb77eeb0e1f9dece3d65859"
+  integrity sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==
+
 reflect.getprototypeof@^1.0.6, reflect.getprototypeof@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz#c629219e78a3316d8b604c765ef68996964e7bf9"
@@ -7287,6 +7331,11 @@ scheduler@^0.27.0:
   version "0.27.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 semver@^5.3.0:
   version "5.7.2"
@@ -8519,6 +8568,13 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
## Summary
- `signUpUseCase` now checks an `IEmailBloomFilterService` before the DB `getUserByEmail` lookup: for the common case (a genuinely new email) the filter says "definitely not taken" and the SELECT is skipped entirely; only a "maybe taken" result falls back to today's exact DB check.
- `EmailBloomFilterService` (infrastructure) wraps a `bloom-filters` `BloomFilter` (sized via new `BLOOM_FILTER_EXPECTED_EMAILS`/`BLOOM_FILTER_ERROR_RATE` config constants), lazily warmed from the DB exactly once per warm process (memoized) via a new `IUsersRepository.getAllEmails()`. This persists across requests on the same warm serverless instance since `@evyweb/ioctopus` bindings default to singleton scope.
- Added a `.unique()` constraint on `users.email` (new migration `0009_orange_black_tarantula.sql`, a single `CREATE UNIQUE INDEX`) as a correctness backstop: since the bloom filter's fast path skips the authoritative check, the DB constraint is what actually prevents a duplicate from being persisted across the filter's blind spots (cold instances, cross-instance writes). A resulting DB conflict is caught in `UsersRepository.createUser` and surfaces as a new `ConflictError`, which the use-case maps to the same `AuthenticationError('Email taken')` users already see today — no behavior change from their perspective.
- New dependency: `bloom-filters` (audited — its own dependency tree introduces no new vulnerabilities).

## Test plan
- [x] New tests: `tests/units/infrastructure/services/email-bloom-filter.service.test.ts` (hit/miss/record against the real DI container + seeded test DB), extended `tests/units/infrastructure/repositories/users.repository.test.ts` (`getAllEmails`, duplicate email → `ConflictError`)
- [x] `vitest run` — 124/124 tests passing
- [x] `tsc --noEmit` clean
- [x] `eslint .` clean, including the `eslint-plugin-boundaries` Clean Architecture layering rules this repo enforces
- [ ] **DB migration not yet applied to the real database** — `.env` points at a remote Turso DB, so I did not run `db:migrate` against it or manually exercise sign-up through the dev server. This needs to be applied deliberately before/at deploy (see migration discussion in the PR description / ask the author).