### PR TITLE
fix: register presenters element type in eslint-plugin-boundaries config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,11 @@ const eslintConfig = [
         },
         {
           mode: 'full',
+          type: 'presenters',
+          pattern: ['src/interface-adapters/presenters/**/*'],
+        },
+        {
+          mode: 'full',
           type: 'use-cases',
           pattern: ['src/application/use-cases/**/*'],
         },
@@ -92,7 +97,12 @@ const eslintConfig = [
                 'service-interfaces',
                 'repository-interfaces',
                 'use-cases',
+                'presenters',
               ],
+            },
+            {
+              from: 'presenters',
+              allow: ['entities', 'service-interfaces'],
             },
             {
               from: 'infrastructure',


### PR DESCRIPTION
## Summary

- The previous refactor introduced a new `src/interface-adapters/presenters/` layer but did not update the `eslint-plugin-boundaries` config, causing CI to fail with `boundaries/no-unknown-files` (presenter files unrecognised) and `boundaries/no-unknown` (controllers importing from an unknown element type)
- Registers `presenters` as a known element type matching `src/interface-adapters/presenters/**/*`
- Adds `presenters` to the `controllers` allow-list so controllers may import from it
- Adds an allow-rule for `presenters` itself, permitting imports from `entities` and `service-interfaces` (the two layers presenters depend on)

## Test plan

- [ ] `yarn run lint` passes with 0 errors locally (verified)
- [ ] GitHub Actions `Test / lint` job passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project rules to support presenter components and their interactions with core application layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->