### PR TITLE
feat: add email verification on sign-up

### DIFF
--- a/app/[locale]/(auth)/verify-email/page.tsx
+++ b/app/[locale]/(auth)/verify-email/page.tsx
@@ -1,0 +1,20 @@
+import { getTranslations } from 'next-intl/server';
+
+import { VerifyEmailForm } from '@/app/_components/verify-email-form';
+
+interface Props {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function Page({ searchParams }: Props) {
+  const t = await getTranslations();
+  const { token } = await searchParams;
+  return (
+    <main className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
+      <h1 className="sr-only">{t('verifyEmail')}</h1>
+      <div className="w-full max-w-sm">
+        <VerifyEmailForm token={token} />
+      </div>
+    </main>
+  );
+}

--- a/app/_components/verify-email-form.tsx
+++ b/app/_components/verify-email-form.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useEffect, useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/app/_components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/app/_components/ui/card';
+import { authActions } from '@/app/actions';
+import { cn } from '@/lib/utils';
+
+interface Props extends React.ComponentPropsWithoutRef<'div'> {
+  token?: string;
+}
+
+export function VerifyEmailForm({ className, token, ...props }: Props) {
+  const t = useTranslations();
+  const [verifying, startVerifying] = useTransition();
+  const [resending, startResending] = useTransition();
+
+  useEffect(() => {
+    if (!token) return;
+    startVerifying(async () => {
+      const res = await authActions.verifyEmail(token);
+      if (res?.error) {
+        toast.error(res.error);
+      }
+    });
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleResend = () => {
+    if (resending) return;
+    startResending(async () => {
+      const res = await authActions.resendVerificationEmail();
+      if (res?.error) {
+        toast.error(res.error);
+      } else {
+        toast.success(t('verifyEmailResendSuccess'));
+      }
+    });
+  };
+
+  return (
+    <div className={cn('flex flex-col gap-6', className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-2xl">{t('verifyEmail')}</CardTitle>
+          <CardDescription>{t('verifyEmailDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-4">
+            {verifying && (
+              <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="animate-spin" size={16} />
+                <span>{t('verifyEmail')}…</span>
+              </div>
+            )}
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={handleResend}
+              disabled={resending || verifying}
+            >
+              {resending && <Loader2 className="animate-spin" />}
+              {t('verifyEmailResend')}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/actions/auth/index.ts
+++ b/app/actions/auth/index.ts
@@ -23,6 +23,13 @@ export async function signUp(formData: FormData) {
       const password = formData.get('password')?.toString();
       const confirmPassword = formData.get('confirmPassword')?.toString();
 
+      const headersList = await headers();
+      const host = headersList.get('host') ?? 'localhost:3000';
+      const protocol =
+        process.env.NODE_ENV === 'production' ? 'https' : 'http';
+      const locale = headersList.get('x-your-custom-locale') ?? 'en';
+      const verifyBaseUrl = `${protocol}://${host}/${locale}/verify-email`;
+
       let sessionCookie: Cookie;
       try {
         const signUpController = getInjection('ISignUpController');
@@ -30,6 +37,7 @@ export async function signUp(formData: FormData) {
           email,
           password,
           confirmPassword,
+          verifyBaseUrl,
         });
         sessionCookie = cookie;
       } catch (err) {
@@ -62,7 +70,75 @@ export async function signUp(formData: FormData) {
         sessionCookie.attributes
       );
 
+      redirect('/verify-email');
+    }
+  );
+}
+
+export async function verifyEmail(token: string) {
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.instrumentServerAction(
+    'verifyEmail',
+    { recordResponse: true },
+    async () => {
+      try {
+        const controller = getInjection('IVerifyEmailController');
+        await controller({ token });
+      } catch (err) {
+        if (err instanceof InputParseError) {
+          return { error: 'Invalid verification link.' };
+        }
+        if (err instanceof AuthenticationError) {
+          return { error: err.message };
+        }
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
+        return {
+          error:
+            'An error happened. The developers have been notified. Please try again later.',
+        };
+      }
+
       redirect('/');
+    }
+  );
+}
+
+export async function resendVerificationEmail() {
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.instrumentServerAction(
+    'resendVerificationEmail',
+    { recordResponse: true },
+    async () => {
+      const cookiesStore = await cookies();
+      const sessionId = cookiesStore.get(SESSION_COOKIE)?.value;
+      if (!sessionId) {
+        return { error: 'Not authenticated.' };
+      }
+
+      const headersList = await headers();
+      const host = headersList.get('host') ?? 'localhost:3000';
+      const protocol =
+        process.env.NODE_ENV === 'production' ? 'https' : 'http';
+      const locale = headersList.get('x-your-custom-locale') ?? 'en';
+      const verifyBaseUrl = `${protocol}://${host}/${locale}/verify-email`;
+
+      try {
+        const authenticationService = getInjection('IAuthenticationService');
+        const { user } = await authenticationService.validateSession(sessionId);
+        const controller = getInjection('IResendVerificationEmailController');
+        await controller({ userId: user.id, verifyBaseUrl });
+      } catch (err) {
+        if (err instanceof InputParseError) {
+          return { error: 'Invalid request.' };
+        }
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
+        return {
+          error:
+            'An error happened. The developers have been notified. Please try again later.',
+        };
+      }
     }
   );
 }

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,8 @@
+import { createClient } from '@libsql/client';
 import { defineConfig } from 'cypress';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: '.env.local' });
 
 export default defineConfig({
   // E2E Testing
@@ -19,6 +23,20 @@ export default defineConfig({
         },
         table(data: unknown) {
           console.table(data);
+          return null;
+        },
+        async verifyUser(email: string) {
+          const url = process.env.DATABASE_URL ?? 'file:sqlite.db';
+          const authToken = process.env.DATABASE_AUTH_TOKEN;
+          const client = createClient({ url, authToken });
+          try {
+            await client.execute({
+              sql: 'UPDATE users SET email_verified = 1 WHERE email = ?',
+              args: [email],
+            });
+          } finally {
+            client.close();
+          }
           return null;
         },
       });

--- a/cypress/e2e/sign-up.cy.ts
+++ b/cypress/e2e/sign-up.cy.ts
@@ -16,6 +16,9 @@ describe('Sign Up Flow', () => {
     cy.getBySel('password').type('admin123');
     cy.getBySel('confirmPassword').type('admin123');
     cy.getBySel('submit').click();
-    cy.getBySel('dashboard-content').should('be.visible');
+    // After sign-up, user lands on the verify-email page
+    cy.url().should('include', '/verify-email');
+    // Mark the user as verified so subsequent test specs can log in normally
+    cy.task('verifyUser', 'test@test.com');
   });
 });

--- a/di/container.ts
+++ b/di/container.ts
@@ -5,6 +5,7 @@ import { createAuthenticationModule } from '@/di/modules/authentication.module';
 import { createTransactionManagerModule } from '@/di/modules/database.module';
 import { createLeavesModule } from '@/di/modules/leaves.module';
 import { createMonitoringModule } from '@/di/modules/monitoring.module';
+import { createEmailVerificationModule } from '@/di/modules/email-verification.module';
 import { createPasswordResetModule } from '@/di/modules/password-reset.module';
 import { createUserSettingModule } from '@/di/modules/user-settings.module';
 import { createUsersModule } from '@/di/modules/users.module';
@@ -32,6 +33,10 @@ ApplicationContainer.load(
 ApplicationContainer.load(
   Symbol('PasswordResetModule'),
   createPasswordResetModule()
+);
+ApplicationContainer.load(
+  Symbol('EmailVerificationModule'),
+  createEmailVerificationModule()
 );
 
 export function getInjection<K extends keyof typeof DI_SYMBOLS>(

--- a/di/modules/authentication.module.ts
+++ b/di/modules/authentication.module.ts
@@ -42,6 +42,8 @@ export function createAuthenticationModule() {
       DI_SYMBOLS.IUsersRepository,
       DI_SYMBOLS.IUserSettingsRepository,
       DI_SYMBOLS.IEmailBloomFilterService,
+      DI_SYMBOLS.IEmailVerificationTokensRepository,
+      DI_SYMBOLS.IEmailService,
     ]);
 
   authenticationModule

--- a/di/modules/email-verification.module.ts
+++ b/di/modules/email-verification.module.ts
@@ -1,0 +1,52 @@
+import { createModule } from '@evyweb/ioctopus';
+
+import { DI_SYMBOLS } from '@/di/types';
+import { resendVerificationEmailUseCase } from '@/src/application/use-cases/auth/resend-verification-email.use-case';
+import { verifyEmailUseCase } from '@/src/application/use-cases/auth/verify-email.use-case';
+import { EmailVerificationTokensRepository } from '@/src/infrastructure/repositories/email-verification-tokens.repository';
+import { resendVerificationEmailController } from '@/src/interface-adapters/controllers/auth/resend-verification-email.controller';
+import { verifyEmailController } from '@/src/interface-adapters/controllers/auth/verify-email.controller';
+
+export function createEmailVerificationModule() {
+  const emailVerificationModule = createModule();
+
+  emailVerificationModule
+    .bind(DI_SYMBOLS.IEmailVerificationTokensRepository)
+    .toClass(EmailVerificationTokensRepository, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ICrashReporterService,
+    ]);
+
+  emailVerificationModule
+    .bind(DI_SYMBOLS.IVerifyEmailUseCase)
+    .toHigherOrderFunction(verifyEmailUseCase, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IEmailVerificationTokensRepository,
+      DI_SYMBOLS.IUsersRepository,
+    ]);
+
+  emailVerificationModule
+    .bind(DI_SYMBOLS.IResendVerificationEmailUseCase)
+    .toHigherOrderFunction(resendVerificationEmailUseCase, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IUsersRepository,
+      DI_SYMBOLS.IEmailVerificationTokensRepository,
+      DI_SYMBOLS.IEmailService,
+    ]);
+
+  emailVerificationModule
+    .bind(DI_SYMBOLS.IVerifyEmailController)
+    .toHigherOrderFunction(verifyEmailController, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IVerifyEmailUseCase,
+    ]);
+
+  emailVerificationModule
+    .bind(DI_SYMBOLS.IResendVerificationEmailController)
+    .toHigherOrderFunction(resendVerificationEmailController, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IResendVerificationEmailUseCase,
+    ]);
+
+  return emailVerificationModule;
+}

--- a/di/types.ts
+++ b/di/types.ts
@@ -1,3 +1,4 @@
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
 import { IPasswordResetTokensRepository } from '@/src/application/repositories/password-reset-tokens.repository.interface';
 import { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
 import { ISessionsRepository } from '@/src/application/repositories/sessions.repository.interface';
@@ -9,6 +10,8 @@ import { IEmailBloomFilterService } from '@/src/application/services/email-bloom
 import { IEmailService } from '@/src/application/services/email.service.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
+import { IResendVerificationEmailUseCase } from '@/src/application/use-cases/auth/resend-verification-email.use-case';
+import { IVerifyEmailUseCase } from '@/src/application/use-cases/auth/verify-email.use-case';
 import { IRequestPasswordResetUseCase } from '@/src/application/use-cases/auth/request-password-reset.use-case';
 import { IResetPasswordUseCase } from '@/src/application/use-cases/auth/reset-password.use-case';
 import { ISignInUseCase } from '@/src/application/use-cases/auth/sign-in.use-case';
@@ -24,6 +27,8 @@ import { IUpdateUserSettingsUseCase } from '@/src/application/use-cases/user-set
 import { IGetUserUseCase } from '@/src/application/use-cases/users/get-user.use-case';
 import { IUpdateUserEmailUseCase } from '@/src/application/use-cases/users/update-user-email.use-case';
 import { IUpdateUserPasswordUseCase } from '@/src/application/use-cases/users/update-user-password.use-case';
+import { IResendVerificationEmailController } from '@/src/interface-adapters/controllers/auth/resend-verification-email.controller';
+import { IVerifyEmailController } from '@/src/interface-adapters/controllers/auth/verify-email.controller';
 import { IRequestPasswordResetController } from '@/src/interface-adapters/controllers/auth/request-password-reset.controller';
 import { IResetPasswordController } from '@/src/interface-adapters/controllers/auth/reset-password.controller';
 import { ISignInController } from '@/src/interface-adapters/controllers/auth/sign-in.controller';
@@ -55,6 +60,7 @@ export const DI_SYMBOLS = {
   ISessionRepository: Symbol.for('ISessionRepository'),
   IUserSettingsRepository: Symbol.for('IUserSettingsRepository'),
   IPasswordResetTokensRepository: Symbol.for('IPasswordResetTokensRepository'),
+  IEmailVerificationTokensRepository: Symbol.for('IEmailVerificationTokensRepository'),
 
   // Use Cases
   ICreateLeaveUseCase: Symbol.for('ICreateLeaveUseCase'),
@@ -67,6 +73,8 @@ export const DI_SYMBOLS = {
   ISignUpUseCase: Symbol.for('ISignUpUseCase'),
   IRequestPasswordResetUseCase: Symbol.for('IRequestPasswordResetUseCase'),
   IResetPasswordUseCase: Symbol.for('IResetPasswordUseCase'),
+  IVerifyEmailUseCase: Symbol.for('IVerifyEmailUseCase'),
+  IResendVerificationEmailUseCase: Symbol.for('IResendVerificationEmailUseCase'),
   IGetUserUseCase: Symbol.for('IGetUserUseCase'),
   IUpdateUserEmailUseCase: Symbol.for('IUpdateUserEmailUseCase'),
   IUpdateUserPasswordUseCase: Symbol.for('IUpdateUserPasswordUseCase'),
@@ -79,6 +87,8 @@ export const DI_SYMBOLS = {
   ISignUpController: Symbol.for('ISignUpController'),
   IRequestPasswordResetController: Symbol.for('IRequestPasswordResetController'),
   IResetPasswordController: Symbol.for('IResetPasswordController'),
+  IVerifyEmailController: Symbol.for('IVerifyEmailController'),
+  IResendVerificationEmailController: Symbol.for('IResendVerificationEmailController'),
   ICreateLeaveController: Symbol.for('ICreateLeaveController'),
   IDeleteLeaveController: Symbol.for('IDeleteLeaveController'),
   IGetLeavesForUserController: Symbol.for('IGetLeavesForUserController'),
@@ -108,6 +118,7 @@ export interface DI_RETURN_TYPES {
   ISessionRepository: ISessionsRepository;
   IUserSettingsRepository: IUserSettingsRepository;
   IPasswordResetTokensRepository: IPasswordResetTokensRepository;
+  IEmailVerificationTokensRepository: IEmailVerificationTokensRepository;
 
   // Use Cases
   ICreateLeaveUseCase: ICreateLeaveUseCase;
@@ -120,6 +131,8 @@ export interface DI_RETURN_TYPES {
   ISignUpUseCase: ISignUpUseCase;
   IRequestPasswordResetUseCase: IRequestPasswordResetUseCase;
   IResetPasswordUseCase: IResetPasswordUseCase;
+  IVerifyEmailUseCase: IVerifyEmailUseCase;
+  IResendVerificationEmailUseCase: IResendVerificationEmailUseCase;
   IGetUserUseCase: IGetUserUseCase;
   IUpdateUserEmailUseCase: IUpdateUserEmailUseCase;
   IUpdateUserPasswordUseCase: IUpdateUserPasswordUseCase;
@@ -132,6 +145,8 @@ export interface DI_RETURN_TYPES {
   ISignUpController: ISignUpController;
   IRequestPasswordResetController: IRequestPasswordResetController;
   IResetPasswordController: IResetPasswordController;
+  IVerifyEmailController: IVerifyEmailController;
+  IResendVerificationEmailController: IResendVerificationEmailController;
   ICreateLeaveController: ICreateLeaveController;
   IDeleteLeaveController: IDeleteLeaveController;
   IGetLeaveController: IGetLeaveController;

--- a/drizzle/index.ts
+++ b/drizzle/index.ts
@@ -3,7 +3,7 @@ import { ExtractTablesWithRelations } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/libsql';
 import { SQLiteTransaction } from 'drizzle-orm/sqlite-core';
 
-import { leaves, passwordResetTokens, sessions, userSettings, users } from './schema';
+import { emailVerificationTokens, leaves, passwordResetTokens, sessions, userSettings, users } from './schema';
 
 const connectionString = process.env.DATABASE_URL;
 const databaseToken = process.env.DATABASE_AUTH_TOKEN;
@@ -22,7 +22,7 @@ if (isTesting) {
 export const client = createClient(dbCredentials);
 
 export const db = drizzle(client, {
-  schema: { users, sessions, leaves, userSettings, passwordResetTokens },
+  schema: { users, sessions, leaves, userSettings, passwordResetTokens, emailVerificationTokens },
 });
 
 type Schema = {
@@ -31,6 +31,7 @@ type Schema = {
   leaves: typeof leaves;
   userSettings: typeof userSettings;
   passwordResetTokens: typeof passwordResetTokens;
+  emailVerificationTokens: typeof emailVerificationTokens;
 };
 
 export type Transaction = SQLiteTransaction<

--- a/drizzle/migrations/0011_loose_loners.sql
+++ b/drizzle/migrations/0011_loose_loners.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `email_verification_tokens` (
+	`token_hash` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`expires_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+ALTER TABLE `users` ADD `email_verified` integer DEFAULT true NOT NULL;

--- a/drizzle/migrations/meta/0010_snapshot.json
+++ b/drizzle/migrations/meta/0010_snapshot.json
@@ -1,0 +1,280 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3428e574-ffc8-4a46-92cd-849da3020194",
+  "prevId": "5e188cda-de2c-4561-8ead-66939330d044",
+  "tables": {
+    "leaves": {
+      "name": "leaves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaves_user_id_users_id_fk": {
+          "name": "leaves_user_id_users_id_fk",
+          "tableFrom": "leaves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "visa_start_date": {
+          "name": "visa_start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visa_expiry_date": {
+          "name": "visa_expiry_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/0011_snapshot.json
+++ b/drizzle/migrations/meta/0011_snapshot.json
@@ -1,0 +1,333 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e9d65258-1548-44b9-9059-92624c79557f",
+  "prevId": "3428e574-ffc8-4a46-92cd-849da3020194",
+  "tables": {
+    "email_verification_tokens": {
+      "name": "email_verification_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_verification_tokens_user_id_users_id_fk": {
+          "name": "email_verification_tokens_user_id_users_id_fk",
+          "tableFrom": "email_verification_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leaves": {
+      "name": "leaves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "remarks": {
+          "name": "remarks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "leaves_user_id_users_id_fk": {
+          "name": "leaves_user_id_users_id_fk",
+          "tableFrom": "leaves",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "password_reset_tokens": {
+      "name": "password_reset_tokens",
+      "columns": {
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "password_reset_tokens_user_id_users_id_fk": {
+          "name": "password_reset_tokens_user_id_users_id_fk",
+          "tableFrom": "password_reset_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "visa_start_date": {
+          "name": "visa_start_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visa_expiry_date": {
+          "name": "visa_expiry_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "arrival_date": {
+          "name": "arrival_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -71,6 +71,20 @@
       "when": 1782305442322,
       "tag": "0009_orange_black_tarantula",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1782905178215,
+      "tag": "0010_red_bromley",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1782909335478,
+      "tag": "0011_loose_loners",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -5,6 +5,9 @@ export const users = sqliteTable('users', {
   id: text('id').primaryKey().notNull(),
   email: text('email').notNull().unique(),
   passwordHash: text('password_hash').notNull(),
+  emailVerified: integer('email_verified', { mode: 'boolean' })
+    .notNull()
+    .default(true),
 });
 
 export const sessions = sqliteTable('sessions', {
@@ -46,3 +49,14 @@ export const passwordResetTokens = sqliteTable('password_reset_tokens', {
     .notNull(),
   expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
 });
+
+export const emailVerificationTokens = sqliteTable(
+  'email_verification_tokens',
+  {
+    tokenHash: text('token_hash').primaryKey().notNull(),
+    userId: text('user_id')
+      .references(() => users.id)
+      .notNull(),
+    expiresAt: integer('expires_at', { mode: 'timestamp' }).notNull(),
+  }
+);

--- a/lighthouse-auth-script.js
+++ b/lighthouse-auth-script.js
@@ -3,6 +3,8 @@
 // only way in (no header-based auth). LHCI hands us the shared `Browser`
 // (not a `Page`) and reuses its cookies for the page it then audits.
 module.exports = async (browser) => {
+  require('dotenv').config({ path: '.env.local' });
+
   const email = `lhci-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
   const password = 'lighthouse-ci-password';
 
@@ -16,6 +18,26 @@ module.exports = async (browser) => {
   await page.type('[data-cy=confirmPassword]', password);
   await page.click('[data-cy=submit]');
 
+  // After sign-up, user is redirected to /verify-email (email not yet confirmed)
+  await page.waitForNavigation({ waitUntil: 'networkidle0', timeout: 30000 });
+
+  // Mark user as verified directly in the DB — email delivery is not possible
+  // in CI, so we bypass it here the same way the Cypress verifyUser task does.
+  const { createClient } = require('@libsql/client');
+  const url = process.env.DATABASE_URL ?? 'file:sqlite.db';
+  const authToken = process.env.DATABASE_AUTH_TOKEN;
+  const client = createClient({ url, authToken });
+  try {
+    await client.execute({
+      sql: 'UPDATE users SET email_verified = 1 WHERE email = ?',
+      args: [email],
+    });
+  } finally {
+    client.close();
+  }
+
+  // Navigate to the dashboard now that the session user is verified
+  await page.goto('http://localhost:3000/en', { waitUntil: 'networkidle0' });
   await page.waitForSelector('[data-cy=dashboard-content]', {
     timeout: 30000,
   });

--- a/lighthouse-auth-script.js
+++ b/lighthouse-auth-script.js
@@ -3,6 +3,7 @@
 // only way in (no header-based auth). LHCI hands us the shared `Browser`
 // (not a `Page`) and reuses its cookies for the page it then audits.
 module.exports = async (browser) => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS script loaded directly by LHCI
   require('dotenv').config({ path: '.env.local' });
 
   const email = `lhci-${Date.now()}-${Math.random().toString(36).slice(2)}@test.com`;
@@ -23,6 +24,7 @@ module.exports = async (browser) => {
 
   // Mark user as verified directly in the DB — email delivery is not possible
   // in CI, so we bypass it here the same way the Cypress verifyUser task does.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- CJS script loaded directly by LHCI
   const { createClient } = require('@libsql/client');
   const url = process.env.DATABASE_URL ?? 'file:sqlite.db';
   const authToken = process.env.DATABASE_AUTH_TOKEN;

--- a/messages/en.json
+++ b/messages/en.json
@@ -83,5 +83,11 @@
   "resetLinkSent": "If that email is registered, a reset link has been sent",
   "resetPassword": "Reset Password",
   "resetPasswordDescription": "Enter your new password below",
-  "invalidOrExpiredToken": "Invalid or expired password reset link"
+  "invalidOrExpiredToken": "Invalid or expired password reset link",
+  "verifyEmail": "Verify Your Email",
+  "verifyEmailDescription": "We sent a verification link to your email address. Please check your inbox and click the link to activate your account.",
+  "verifyEmailResend": "Resend verification email",
+  "verifyEmailResendSuccess": "Verification email sent",
+  "verifyEmailSuccess": "Email verified! You are now logged in.",
+  "verifyEmailInvalidToken": "Invalid or expired verification link"
 }

--- a/messages/zh-Hant-HK.json
+++ b/messages/zh-Hant-HK.json
@@ -83,5 +83,11 @@
   "resetLinkSent": "如該電郵已註冊，重置連結已發送",
   "resetPassword": "重置密碼",
   "resetPasswordDescription": "請在下方輸入您的新密碼",
-  "invalidOrExpiredToken": "重置連結無效或已過期"
+  "invalidOrExpiredToken": "重置連結無效或已過期",
+  "verifyEmail": "驗證您的電郵",
+  "verifyEmailDescription": "我們已向您的電郵地址發送了驗證連結，請查看收件箱並點擊連結以啟動您的帳戶。",
+  "verifyEmailResend": "重新發送驗證電郵",
+  "verifyEmailResendSuccess": "驗證電郵已發送",
+  "verifyEmailSuccess": "電郵已驗證！您現已登入。",
+  "verifyEmailInvalidToken": "驗證連結無效或已過期"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lighthouse": "lhci autorun",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
+    "db:migrate:prod": "node --env-file=.env.production ./node_modules/.bin/drizzle-kit migrate",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/proxy.ts
+++ b/proxy.ts
@@ -6,7 +6,7 @@ import { getInjection } from './di/container';
 
 type localeType = 'en' | 'zh-Hant-HK';
 
-const AUTH_PATHS = ['sign-in', 'sign-up', 'forgot-password', 'reset-password'];
+const AUTH_PATHS = ['sign-in', 'sign-up', 'forgot-password', 'reset-password', 'verify-email'];
 
 export default async function proxy(request: NextRequest) {
   // Step 1: Use the incoming request (example)
@@ -34,13 +34,18 @@ export default async function proxy(request: NextRequest) {
     }
     try {
       const authenticationService = getInjection('IAuthenticationService');
-      const { session } =
+      const { session, user } =
         await authenticationService.validateSession(sessionId);
       const cookie = authenticationService.buildSessionCookie(
         sessionId,
         session.expiresAt
       );
       response.cookies.set(cookie.name, cookie.value, cookie.attributes);
+      if (!user.emailVerified) {
+        return NextResponse.redirect(
+          new URL(`/${defaultLocale}/verify-email`, request.url)
+        );
+      }
     } catch {
       return NextResponse.redirect(
         new URL(`/${defaultLocale}/sign-in`, request.url)

--- a/src/application/repositories/email-verification-tokens.repository.interface.ts
+++ b/src/application/repositories/email-verification-tokens.repository.interface.ts
@@ -1,0 +1,8 @@
+import { EmailVerificationToken } from '@/src/entities/models/email-verification-token';
+
+export interface IEmailVerificationTokensRepository {
+  createToken(tokenHash: string, userId: string, expiresAt: Date): Promise<void>;
+  getToken(tokenHash: string): Promise<EmailVerificationToken | undefined>;
+  deleteToken(tokenHash: string): Promise<void>;
+  deleteTokensByUserId(userId: string): Promise<void>;
+}

--- a/src/application/repositories/users.repository.interface.ts
+++ b/src/application/repositories/users.repository.interface.ts
@@ -11,4 +11,5 @@ export interface IUsersRepository {
     input: Partial<UpdateUser>,
     tx?: ITransaction
   ): Promise<User>;
+  verifyUserEmail(id: string): Promise<User>;
 }

--- a/src/application/services/email.service.interface.ts
+++ b/src/application/services/email.service.interface.ts
@@ -1,3 +1,4 @@
 export interface IEmailService {
   sendPasswordResetEmail(to: string, resetUrl: string): Promise<void>;
+  sendVerificationEmail(to: string, verifyUrl: string): Promise<void>;
 }

--- a/src/application/use-cases/auth/resend-verification-email.use-case.ts
+++ b/src/application/use-cases/auth/resend-verification-email.use-case.ts
@@ -1,0 +1,52 @@
+import { sha256 } from '@oslojs/crypto/sha2';
+import {
+  encodeBase32LowerCaseNoPadding,
+  encodeHexLowerCase,
+} from '@oslojs/encoding';
+
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
+import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import { IEmailService } from '@/src/application/services/email.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+
+export type IResendVerificationEmailUseCase = ReturnType<
+  typeof resendVerificationEmailUseCase
+>;
+
+export const resendVerificationEmailUseCase =
+  (
+    instrumentationService: IInstrumentationService,
+    usersRepository: IUsersRepository,
+    emailVerificationTokensRepository: IEmailVerificationTokensRepository,
+    emailService: IEmailService
+  ) =>
+  async (userId: string, verifyBaseUrl: string): Promise<void> => {
+    return await instrumentationService.startSpan(
+      { name: 'resendVerificationEmail Use Case' },
+      async () => {
+        const user = await usersRepository.getUser(userId);
+        if (!user || user.emailVerified) {
+          return;
+        }
+
+        await emailVerificationTokensRepository.deleteTokensByUserId(userId);
+
+        const bytes = new Uint8Array(20);
+        crypto.getRandomValues(bytes);
+        const token = encodeBase32LowerCaseNoPadding(bytes);
+        const tokenHash = encodeHexLowerCase(
+          sha256(new TextEncoder().encode(token))
+        );
+
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        await emailVerificationTokensRepository.createToken(
+          tokenHash,
+          userId,
+          expiresAt
+        );
+
+        const verifyUrl = `${verifyBaseUrl}?token=${token}`;
+        await emailService.sendVerificationEmail(user.email, verifyUrl);
+      }
+    );
+  };

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -1,7 +1,15 @@
+import { sha256 } from '@oslojs/crypto/sha2';
+import {
+  encodeBase32LowerCaseNoPadding,
+  encodeHexLowerCase,
+} from '@oslojs/encoding';
+
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
 import { IUserSettingsRepository } from '@/src/application/repositories/user-settings.repository.interface';
 import type { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import type { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
 import type { IEmailBloomFilterService } from '@/src/application/services/email-bloom-filter.service.interface';
+import { IEmailService } from '@/src/application/services/email.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { AuthenticationError } from '@/src/entities/errors/auth';
 import { ConflictError } from '@/src/entities/errors/common';
@@ -17,11 +25,14 @@ export const signUpUseCase =
     authenticationService: IAuthenticationService,
     usersRepository: IUsersRepository,
     userSettingsRepository: IUserSettingsRepository,
-    emailBloomFilterService: IEmailBloomFilterService
+    emailBloomFilterService: IEmailBloomFilterService,
+    emailVerificationTokensRepository: IEmailVerificationTokensRepository,
+    emailService: IEmailService
   ) =>
   (input: {
     email: string;
     password: string;
+    verifyBaseUrl: string;
   }): Promise<{
     session: Session;
     cookie: Cookie;
@@ -58,6 +69,23 @@ export const signUpUseCase =
         await emailBloomFilterService.recordEmail(input.email);
 
         await userSettingsRepository.createUserSettings(userId);
+
+        const bytes = new Uint8Array(20);
+        crypto.getRandomValues(bytes);
+        const token = encodeBase32LowerCaseNoPadding(bytes);
+        const tokenHash = encodeHexLowerCase(
+          sha256(new TextEncoder().encode(token))
+        );
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        await emailVerificationTokensRepository.createToken(
+          tokenHash,
+          userId,
+          expiresAt
+        );
+        await emailService.sendVerificationEmail(
+          input.email,
+          `${input.verifyBaseUrl}?token=${token}`
+        );
 
         const { cookie, session } =
           await authenticationService.createSession(newUser);

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -82,10 +82,15 @@ export const signUpUseCase =
           userId,
           expiresAt
         );
-        await emailService.sendVerificationEmail(
-          input.email,
-          `${input.verifyBaseUrl}?token=${token}`
-        );
+        try {
+          await emailService.sendVerificationEmail(
+            input.email,
+            `${input.verifyBaseUrl}?token=${token}`
+          );
+        } catch {
+          // Email delivery failure is non-fatal: the token is stored and the
+          // user can request a resend from /verify-email.
+        }
 
         const { cookie, session } =
           await authenticationService.createSession(newUser);

--- a/src/application/use-cases/auth/verify-email.use-case.ts
+++ b/src/application/use-cases/auth/verify-email.use-case.ts
@@ -1,0 +1,40 @@
+import { sha256 } from '@oslojs/crypto/sha2';
+import { encodeHexLowerCase } from '@oslojs/encoding';
+
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
+import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+
+export type IVerifyEmailUseCase = ReturnType<typeof verifyEmailUseCase>;
+
+export const verifyEmailUseCase =
+  (
+    instrumentationService: IInstrumentationService,
+    emailVerificationTokensRepository: IEmailVerificationTokensRepository,
+    usersRepository: IUsersRepository
+  ) =>
+  async (token: string): Promise<void> => {
+    return await instrumentationService.startSpan(
+      { name: 'verifyEmail Use Case' },
+      async () => {
+        const tokenHash = encodeHexLowerCase(
+          sha256(new TextEncoder().encode(token))
+        );
+
+        const verificationToken =
+          await emailVerificationTokensRepository.getToken(tokenHash);
+        if (!verificationToken) {
+          throw new AuthenticationError('Invalid or expired verification link');
+        }
+
+        if (Date.now() >= verificationToken.expiresAt.getTime()) {
+          await emailVerificationTokensRepository.deleteToken(tokenHash);
+          throw new AuthenticationError('Invalid or expired verification link');
+        }
+
+        await usersRepository.verifyUserEmail(verificationToken.userId);
+        await emailVerificationTokensRepository.deleteToken(tokenHash);
+      }
+    );
+  };

--- a/src/entities/models/email-verification-token.ts
+++ b/src/entities/models/email-verification-token.ts
@@ -1,0 +1,5 @@
+export type EmailVerificationToken = {
+  tokenHash: string;
+  userId: string;
+  expiresAt: Date;
+};

--- a/src/entities/models/user.ts
+++ b/src/entities/models/user.ts
@@ -4,6 +4,7 @@ export const userSchema = z.object({
   id: z.string(),
   email: z.email(),
   passwordHash: z.string().min(6).max(255),
+  emailVerified: z.boolean(),
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/src/infrastructure/repositories/email-verification-tokens.repository.ts
+++ b/src/infrastructure/repositories/email-verification-tokens.repository.ts
@@ -1,0 +1,119 @@
+import { eq } from 'drizzle-orm';
+
+import { db } from '@/drizzle';
+import { emailVerificationTokens } from '@/drizzle/schema';
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
+import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { EmailVerificationToken } from '@/src/entities/models/email-verification-token';
+
+export class EmailVerificationTokensRepository
+  implements IEmailVerificationTokensRepository
+{
+  constructor(
+    private readonly instrumentationService: IInstrumentationService,
+    private readonly crashReporterService: ICrashReporterService
+  ) {}
+
+  async createToken(
+    tokenHash: string,
+    userId: string,
+    expiresAt: Date
+  ): Promise<void> {
+    return await this.instrumentationService.startSpan(
+      { name: 'EmailVerificationTokensRepository > createToken' },
+      async () => {
+        try {
+          const query = db
+            .insert(emailVerificationTokens)
+            .values({ tokenHash, userId, expiresAt });
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
+        }
+      }
+    );
+  }
+
+  async getToken(
+    tokenHash: string
+  ): Promise<EmailVerificationToken | undefined> {
+    return await this.instrumentationService.startSpan(
+      { name: 'EmailVerificationTokensRepository > getToken' },
+      async () => {
+        try {
+          const query = db.query.emailVerificationTokens.findFirst({
+            where: eq(emailVerificationTokens.tokenHash, tokenHash),
+          });
+          return await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
+        }
+      }
+    );
+  }
+
+  async deleteToken(tokenHash: string): Promise<void> {
+    return await this.instrumentationService.startSpan(
+      { name: 'EmailVerificationTokensRepository > deleteToken' },
+      async () => {
+        try {
+          const query = db
+            .delete(emailVerificationTokens)
+            .where(eq(emailVerificationTokens.tokenHash, tokenHash));
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
+        }
+      }
+    );
+  }
+
+  async deleteTokensByUserId(userId: string): Promise<void> {
+    return await this.instrumentationService.startSpan(
+      { name: 'EmailVerificationTokensRepository > deleteTokensByUserId' },
+      async () => {
+        try {
+          const query = db
+            .delete(emailVerificationTokens)
+            .where(eq(emailVerificationTokens.userId, userId));
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
+        }
+      }
+    );
+  }
+}

--- a/src/infrastructure/repositories/users.repository.ts
+++ b/src/infrastructure/repositories/users.repository.ts
@@ -111,6 +111,7 @@ export class UsersRepository implements IUsersRepository {
             id: input.id,
             email: input.email,
             passwordHash,
+            emailVerified: false,
           };
           const query = db.insert(users).values(newUser).returning();
 
@@ -138,6 +139,37 @@ export class UsersRepository implements IUsersRepository {
           }
           this.crashReporterService.report(err);
           throw err; // TODO: convert to Entities error
+        }
+      }
+    );
+  }
+
+  async verifyUserEmail(id: string): Promise<User> {
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > verifyUserEmail' },
+      async () => {
+        try {
+          const query = db
+            .update(users)
+            .set({ emailVerified: true })
+            .where(eq(users.id, id))
+            .returning();
+          const [updated] = await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+          if (updated) {
+            return updated;
+          } else {
+            throw new DatabaseOperationError('Cannot verify user email.');
+          }
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
         }
       }
     );

--- a/src/infrastructure/services/brevo-email.service.ts
+++ b/src/infrastructure/services/brevo-email.service.ts
@@ -37,4 +37,31 @@ export class BrevoEmailService implements IEmailService {
       throw new Error(`Brevo API error ${response.status}: ${body}`);
     }
   }
+
+  async sendVerificationEmail(to: string, verifyUrl: string): Promise<void> {
+    const response = await fetch('https://api.brevo.com/v3/smtp/email', {
+      method: 'POST',
+      headers: {
+        'api-key': this.apiKey,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        sender: { name: this.senderName, email: this.senderEmail },
+        to: [{ email: to }],
+        subject: 'Verify your email address',
+        htmlContent: `
+          <p>Thank you for signing up!</p>
+          <p><a href="${verifyUrl}">Click here to verify your email address</a></p>
+          <p>This link will expire in 24 hours.</p>
+          <p>If you did not create an account, you can safely ignore this email.</p>
+        `,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Brevo API error ${response.status}: ${body}`);
+    }
+  }
 }

--- a/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
+++ b/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { IResendVerificationEmailUseCase } from '@/src/application/use-cases/auth/resend-verification-email.use-case';
+import { InputParseError } from '@/src/entities/errors/common';
+
+const inputSchema = z.object({
+  userId: z.string().min(1),
+  verifyBaseUrl: z.string().url(),
+});
+
+export type IResendVerificationEmailController = ReturnType<
+  typeof resendVerificationEmailController
+>;
+
+export const resendVerificationEmailController =
+  (
+    instrumentationService: IInstrumentationService,
+    resendVerificationEmailUseCase: IResendVerificationEmailUseCase
+  ) =>
+  async (input: Partial<z.infer<typeof inputSchema>>): Promise<void> => {
+    return await instrumentationService.startSpan(
+      { name: 'resendVerificationEmail Controller' },
+      async () => {
+        const { data, error } = inputSchema.safeParse(input);
+        if (error) {
+          throw new InputParseError('Invalid data', { cause: error });
+        }
+        await resendVerificationEmailUseCase(data.userId, data.verifyBaseUrl);
+      }
+    );
+  };

--- a/src/interface-adapters/controllers/auth/sign-up.controller.ts
+++ b/src/interface-adapters/controllers/auth/sign-up.controller.ts
@@ -9,6 +9,7 @@ const inputSchema = z
     email: z.email(),
     password: z.string().min(6).max(31),
     confirmPassword: z.string().min(6).max(31),
+    verifyBaseUrl: z.string().url(),
   })
   .superRefine(({ password, confirmPassword }, ctx) => {
     if (confirmPassword !== password) {

--- a/src/interface-adapters/controllers/auth/verify-email.controller.ts
+++ b/src/interface-adapters/controllers/auth/verify-email.controller.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { IVerifyEmailUseCase } from '@/src/application/use-cases/auth/verify-email.use-case';
+import { InputParseError } from '@/src/entities/errors/common';
+
+const inputSchema = z.object({
+  token: z.string().min(1),
+});
+
+export type IVerifyEmailController = ReturnType<typeof verifyEmailController>;
+
+export const verifyEmailController =
+  (
+    instrumentationService: IInstrumentationService,
+    verifyEmailUseCase: IVerifyEmailUseCase
+  ) =>
+  async (input: Partial<z.infer<typeof inputSchema>>): Promise<void> => {
+    return await instrumentationService.startSpan(
+      { name: 'verifyEmail Controller' },
+      async () => {
+        const { data, error } = inputSchema.safeParse(input);
+        if (error) {
+          throw new InputParseError('Invalid data', { cause: error });
+        }
+        await verifyEmailUseCase(data.token);
+      }
+    );
+  };

--- a/tests/units/application/use-cases/auth/sign-up.use-case.test.ts
+++ b/tests/units/application/use-cases/auth/sign-up.use-case.test.ts
@@ -1,9 +1,21 @@
-import { expect, it } from 'vitest';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
 
 import { getInjection } from '@/di/container';
 import { AuthenticationError } from '@/src/entities/errors/auth';
 
 const signUpUseCase = getInjection('ISignUpUseCase');
+
+const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
 
 // A great guide on test names
 // https://www.epicweb.dev/talks/how-to-write-better-test-names
@@ -11,6 +23,7 @@ it('returns session and cookie', async () => {
   const result = await signUpUseCase({
     email: 'new@test.com',
     password: 'password-new',
+    verifyBaseUrl: TEST_VERIFY_BASE_URL,
   });
   expect(result).toHaveProperty('session');
   expect(result).toHaveProperty('cookie');
@@ -19,6 +32,10 @@ it('returns session and cookie', async () => {
 
 it('throws for invalid input', async () => {
   await expect(() =>
-    signUpUseCase({ email: 'one@test.com', password: 'doesntmatter' })
+    signUpUseCase({
+      email: 'one@test.com',
+      password: 'doesntmatter',
+      verifyBaseUrl: TEST_VERIFY_BASE_URL,
+    })
   ).rejects.toBeInstanceOf(AuthenticationError);
 });

--- a/tests/units/application/use-cases/users/update-user-password.use-case.test.ts
+++ b/tests/units/application/use-cases/users/update-user-password.use-case.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
 
 import { getInjection } from '@/di/container';
 import { AuthenticationError } from '@/src/entities/errors/auth';
@@ -7,10 +7,23 @@ const signInUseCase = getInjection('ISignInUseCase');
 const signUpUseCase = getInjection('ISignUpUseCase');
 const updateUserPasswordUseCase = getInjection('IUpdateUserPasswordUseCase');
 
+const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
 it('update user password', async () => {
   const { session, user } = await signUpUseCase({
     email: 'four@test.com',
     password: 'password-four',
+    verifyBaseUrl: TEST_VERIFY_BASE_URL,
   });
 
   await updateUserPasswordUseCase(
@@ -35,6 +48,7 @@ it('throws authentication error', async () => {
   const { session, user } = await signUpUseCase({
     email: 'five@test.com',
     password: 'password-five',
+    verifyBaseUrl: TEST_VERIFY_BASE_URL,
   });
   await expect(
     updateUserPasswordUseCase(

--- a/tests/units/interface-adapters/controllers/auth/sign-up.controller.test.ts
+++ b/tests/units/interface-adapters/controllers/auth/sign-up.controller.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from 'vitest';
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
 
 import { SESSION_COOKIE } from '@/config';
 
@@ -8,6 +8,18 @@ import { InputParseError } from '@/src/entities/errors/common';
 
 const signUpController = getInjection('ISignUpController');
 
+const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
 // A great guide on test names
 // https://www.epicweb.dev/talks/how-to-write-better-test-names
 it('returns cookie', async () => {
@@ -15,6 +27,7 @@ it('returns cookie', async () => {
     email: 'newUser@test.com',
     password: 'password',
     confirmPassword: 'password',
+    verifyBaseUrl: TEST_VERIFY_BASE_URL,
   });
 
   expect(user).toBeDefined();
@@ -34,6 +47,7 @@ it('throws for invalid input', async () => {
       email: 'no',
       password: 'no',
       confirmPassword: 'nah',
+      verifyBaseUrl: TEST_VERIFY_BASE_URL,
     })
   ).rejects.toBeInstanceOf(InputParseError);
 
@@ -43,6 +57,7 @@ it('throws for invalid input', async () => {
       email: 'nikolovlazar',
       password: 'password',
       confirmPassword: 'passwords',
+      verifyBaseUrl: TEST_VERIFY_BASE_URL,
     })
   ).rejects.toBeInstanceOf(InputParseError);
 });
@@ -53,6 +68,7 @@ it('throws for existing email', async () => {
       email: 'one@test.com',
       password: 'doesntmatter',
       confirmPassword: 'doesntmatter',
+      verifyBaseUrl: TEST_VERIFY_BASE_URL,
     })
   ).rejects.toBeInstanceOf(AuthenticationError);
 });


### PR DESCRIPTION
## Summary

- After sign-up, a user receives a Brevo email with a 24-hour verification link. Their session is created immediately but the middleware redirects them to `/verify-email` until they click the link.
- Existing users are grandfathered as verified (DB migration defaults `email_verified = 1` for existing rows).
- A resend button on the `/verify-email` page generates a fresh token and sends a new email.

**New DB objects:**
- `email_verified` column on `users` (INTEGER, `DEFAULT 1`, `NOT NULL`)
- `email_verification_tokens` table (mirrors `password_reset_tokens`, 24h TTL)

**Architecture layers touched:**
- Entities: `User` model gains `emailVerified: boolean`; new `EmailVerificationToken` type
- Application: `IEmailService` gains `sendVerificationEmail`; `IUsersRepository` gains `verifyUserEmail`; new `verify-email` and `resend-verification-email` use cases; sign-up use case now accepts `verifyBaseUrl`
- Infrastructure: `UsersRepository.createUser` sets `emailVerified: false`; new `EmailVerificationTokensRepository`; `BrevoEmailService` implements `sendVerificationEmail`
- Interface-adapters: new `verify-email` and `resend-verification-email` controllers; sign-up controller accepts `verifyBaseUrl`
- DI: new `email-verification.module.ts`; 5 new DI symbols; authentication module updated
- Proxy: `verify-email` added to `AUTH_PATHS`; unverified users redirected to `/verify-email`
- UI: new `/verify-email` page + `VerifyEmailForm` component

## Test plan

- [ ] Run `yarn vitest run` — all 124 tests pass
- [ ] Run `npx tsc --noEmit` — no type errors
- [ ] Run `yarn lint` — no errors
- [ ] Manual: sign up → receive verification email → `/verify-email` page appears → click link → land on `/`
- [ ] Manual: without clicking link, navigate to `/` → redirected back to `/verify-email`
- [ ] Manual: click resend button → new email received, old link invalidated
- [ ] Manual: existing user signs in → no disruption (already verified)
- [ ] Apply migration to production: `DATABASE_URL=... DATABASE_AUTH_TOKEN=... yarn db:migrate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an email verification flow with a dedicated page, verification form, resend option, and translated messages.
  * New verification emails are sent after sign-up, with support for resending a fresh link.
  * Accounts now track whether an email address has been verified.

* **Bug Fixes**
  * Unverified users are redirected to verify their email before continuing.
  * Verification links are now validated and expire safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->