### PR TITLE
fix: host-header injection and missing session revocation on password reset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,9 @@ DATABASE_AUTH_TOKEN=
 BREVO_API_KEY=
 BREVO_SENDER_EMAIL=
 BREVO_SENDER_NAME=
+
+# Trusted origin (no trailing slash) used to build links emailed to users
+# (password reset, email verification). Required in production — the app
+# will refuse to start without it rather than fall back to the request's
+# `Host` header, which is attacker-controlled.
+APP_URL=http://localhost:3000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ concurrency:
 # Centralize environment variables
 env:
   NODE_VERSION: '22.x'
+  # e2e-tests and lighthouse build/run Next.js in production mode
+  # (`next build`/`next start` force NODE_ENV=production), which requires
+  # a trusted APP_URL to be configured -- see config.ts.
+  APP_URL: http://localhost:3000
 
 permissions:
   contents: read

--- a/app/actions/auth/index.ts
+++ b/app/actions/auth/index.ts
@@ -3,7 +3,7 @@
 import { cookies, headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 
-import { SESSION_COOKIE } from '@/config';
+import { DEFAULT_LOCALE, SESSION_COOKIE, SUPPORTED_LOCALES } from '@/config';
 
 import { getInjection } from '@/di/container';
 import {
@@ -12,6 +12,19 @@ import {
 } from '@/src/entities/errors/auth';
 import { InputParseError } from '@/src/entities/errors/common';
 import { Cookie } from '@/src/entities/models/cookie';
+
+// SECURITY: resolves the current request's locale for building links that
+// get emailed to users (password reset, email verification). The locale
+// header is client-influenceable, but it only ever selects a path segment
+// under our own trusted APP_URL — see `config.ts` — never the origin/host
+// itself, so it cannot be used to redirect a link to an attacker's domain.
+async function resolveLocale() {
+  const headersList = await headers();
+  const requested = headersList.get('x-your-custom-locale');
+  return (SUPPORTED_LOCALES as readonly string[]).includes(requested ?? '')
+    ? (requested as (typeof SUPPORTED_LOCALES)[number])
+    : DEFAULT_LOCALE;
+}
 
 export async function signUp(formData: FormData) {
   const instrumentationService = getInjection('IInstrumentationService');
@@ -22,13 +35,7 @@ export async function signUp(formData: FormData) {
       const email = formData.get('email')?.toString();
       const password = formData.get('password')?.toString();
       const confirmPassword = formData.get('confirmPassword')?.toString();
-
-      const headersList = await headers();
-      const host = headersList.get('host') ?? 'localhost:3000';
-      const protocol =
-        process.env.NODE_ENV === 'production' ? 'https' : 'http';
-      const locale = headersList.get('x-your-custom-locale') ?? 'en';
-      const verifyBaseUrl = `${protocol}://${host}/${locale}/verify-email`;
+      const locale = await resolveLocale();
 
       let sessionCookie: Cookie;
       try {
@@ -37,7 +44,7 @@ export async function signUp(formData: FormData) {
           email,
           password,
           confirmPassword,
-          verifyBaseUrl,
+          locale,
         });
         sessionCookie = cookie;
       } catch (err) {
@@ -116,18 +123,13 @@ export async function resendVerificationEmail() {
         return { error: 'Not authenticated.' };
       }
 
-      const headersList = await headers();
-      const host = headersList.get('host') ?? 'localhost:3000';
-      const protocol =
-        process.env.NODE_ENV === 'production' ? 'https' : 'http';
-      const locale = headersList.get('x-your-custom-locale') ?? 'en';
-      const verifyBaseUrl = `${protocol}://${host}/${locale}/verify-email`;
+      const locale = await resolveLocale();
 
       try {
         const authenticationService = getInjection('IAuthenticationService');
         const { user } = await authenticationService.validateSession(sessionId);
         const controller = getInjection('IResendVerificationEmailController');
-        await controller({ userId: user.id, verifyBaseUrl });
+        await controller({ userId: user.id, locale });
       } catch (err) {
         if (err instanceof InputParseError) {
           return { error: 'Invalid request.' };
@@ -193,16 +195,11 @@ export async function requestPasswordReset(formData: FormData) {
     { recordResponse: true },
     async () => {
       const email = formData.get('email')?.toString();
-      const headersList = await headers();
-      const host = headersList.get('host') ?? 'localhost:3000';
-      const protocol =
-        process.env.NODE_ENV === 'production' ? 'https' : 'http';
-      const locale = headersList.get('x-your-custom-locale') ?? 'en';
-      const resetBaseUrl = `${protocol}://${host}/${locale}/reset-password`;
+      const locale = await resolveLocale();
 
       try {
         const controller = getInjection('IRequestPasswordResetController');
-        await controller({ email, resetBaseUrl });
+        await controller({ email, locale });
       } catch (err) {
         if (err instanceof InputParseError) {
           return { error: 'Please enter a valid email address.' };

--- a/config.ts
+++ b/config.ts
@@ -4,3 +4,29 @@ export const SESSION_EXPIRY_MS = 1000 * 60 * 60 * 24 * 30;
 export const SESSION_RENEWAL_THRESHOLD_MS = 1000 * 60 * 60 * 24 * 15;
 export const BLOOM_FILTER_EXPECTED_EMAILS = 10000;
 export const BLOOM_FILTER_ERROR_RATE = 0.01;
+
+// Locales the app actually serves. Keep in sync with `i18n/routing.ts`.
+export const SUPPORTED_LOCALES = ['en', 'zh-Hant-HK'] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+export const DEFAULT_LOCALE: SupportedLocale = 'en';
+
+// Trusted, server-configured origin used to build links (password reset,
+// email verification, etc.) that get emailed to users.
+//
+// SECURITY: this must NEVER be derived from the incoming request's `Host`
+// header. The `Host` header is attacker-controlled, and using it here would
+// let an attacker poison password-reset/email-verification emails with a
+// link to an attacker-controlled domain, leaking valid single-use tokens
+// (CWE-640, "password reset poisoning").
+function resolveAppUrl(): string {
+  const configured = process.env.APP_URL;
+  if (configured) {
+    return configured.replace(/\/+$/, '');
+  }
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('APP_URL environment variable must be set in production');
+  }
+  return 'http://localhost:3000';
+}
+
+export const APP_URL = resolveAppUrl();

--- a/di/modules/password-reset.module.ts
+++ b/di/modules/password-reset.module.ts
@@ -37,6 +37,7 @@ export function createPasswordResetModule() {
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.IPasswordResetTokensRepository,
       DI_SYMBOLS.IUsersRepository,
+      DI_SYMBOLS.ISessionRepository,
     ]);
 
   passwordResetModule

--- a/src/application/use-cases/auth/request-password-reset.use-case.ts
+++ b/src/application/use-cases/auth/request-password-reset.use-case.ts
@@ -4,6 +4,8 @@ import {
   encodeHexLowerCase,
 } from '@oslojs/encoding';
 
+import { APP_URL, SupportedLocale } from '@/config';
+
 import { IPasswordResetTokensRepository } from '@/src/application/repositories/password-reset-tokens.repository.interface';
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IEmailService } from '@/src/application/services/email.service.interface';
@@ -20,7 +22,7 @@ export const requestPasswordResetUseCase =
     passwordResetTokensRepository: IPasswordResetTokensRepository,
     emailService: IEmailService
   ) =>
-  async (email: string, resetBaseUrl: string): Promise<void> => {
+  async (email: string, locale: SupportedLocale): Promise<void> => {
     return await instrumentationService.startSpan(
       { name: 'requestPasswordReset Use Case' },
       async () => {
@@ -46,7 +48,10 @@ export const requestPasswordResetUseCase =
           expiresAt
         );
 
-        const resetUrl = `${resetBaseUrl}?token=${token}`;
+        // SECURITY: the base URL is always built from the trusted, server-
+        // configured APP_URL — never from client input or the `Host` header —
+        // to prevent password-reset link poisoning (CWE-640).
+        const resetUrl = `${APP_URL}/${locale}/reset-password?token=${token}`;
         await emailService.sendPasswordResetEmail(email, resetUrl);
       }
     );

--- a/src/application/use-cases/auth/resend-verification-email.use-case.ts
+++ b/src/application/use-cases/auth/resend-verification-email.use-case.ts
@@ -4,6 +4,8 @@ import {
   encodeHexLowerCase,
 } from '@oslojs/encoding';
 
+import { APP_URL, SupportedLocale } from '@/config';
+
 import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IEmailService } from '@/src/application/services/email.service.interface';
@@ -20,7 +22,7 @@ export const resendVerificationEmailUseCase =
     emailVerificationTokensRepository: IEmailVerificationTokensRepository,
     emailService: IEmailService
   ) =>
-  async (userId: string, verifyBaseUrl: string): Promise<void> => {
+  async (userId: string, locale: SupportedLocale): Promise<void> => {
     return await instrumentationService.startSpan(
       { name: 'resendVerificationEmail Use Case' },
       async () => {
@@ -45,7 +47,10 @@ export const resendVerificationEmailUseCase =
           expiresAt
         );
 
-        const verifyUrl = `${verifyBaseUrl}?token=${token}`;
+        // SECURITY: the base URL is always built from the trusted, server-
+        // configured APP_URL — never from client input or the `Host` header —
+        // to prevent verification-link poisoning (CWE-640).
+        const verifyUrl = `${APP_URL}/${locale}/verify-email?token=${token}`;
         await emailService.sendVerificationEmail(user.email, verifyUrl);
       }
     );

--- a/src/application/use-cases/auth/reset-password.use-case.ts
+++ b/src/application/use-cases/auth/reset-password.use-case.ts
@@ -2,6 +2,7 @@ import { sha256 } from '@oslojs/crypto/sha2';
 import { encodeHexLowerCase } from '@oslojs/encoding';
 
 import { IPasswordResetTokensRepository } from '@/src/application/repositories/password-reset-tokens.repository.interface';
+import { ISessionsRepository } from '@/src/application/repositories/sessions.repository.interface';
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { AuthenticationError } from '@/src/entities/errors/auth';
@@ -12,7 +13,8 @@ export const resetPasswordUseCase =
   (
     instrumentationService: IInstrumentationService,
     passwordResetTokensRepository: IPasswordResetTokensRepository,
-    usersRepository: IUsersRepository
+    usersRepository: IUsersRepository,
+    sessionsRepository: ISessionsRepository
   ) =>
   async (token: string, newPassword: string): Promise<void> => {
     return await instrumentationService.startSpan(
@@ -41,6 +43,13 @@ export const resetPasswordUseCase =
           password: newPassword,
         });
         await passwordResetTokensRepository.deleteToken(tokenHash);
+
+        // SECURITY: forgot-password reset is the account-recovery path used
+        // when a user suspects their credentials were compromised. Revoke
+        // every existing session (there is no "current" session to spare
+        // here, unlike an in-app password change) so a stolen session
+        // cookie can no longer be used after the owner regains control.
+        await sessionsRepository.deleteUserSession(resetToken.userId);
       }
     );
   };

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -4,6 +4,8 @@ import {
   encodeHexLowerCase,
 } from '@oslojs/encoding';
 
+import { APP_URL, SupportedLocale } from '@/config';
+
 import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
 import { IUserSettingsRepository } from '@/src/application/repositories/user-settings.repository.interface';
 import type { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
@@ -32,7 +34,7 @@ export const signUpUseCase =
   (input: {
     email: string;
     password: string;
-    verifyBaseUrl: string;
+    locale: SupportedLocale;
   }): Promise<{
     session: Session;
     cookie: Cookie;
@@ -83,10 +85,11 @@ export const signUpUseCase =
           expiresAt
         );
         try {
-          await emailService.sendVerificationEmail(
-            input.email,
-            `${input.verifyBaseUrl}?token=${token}`
-          );
+          // SECURITY: the base URL is always built from the trusted, server-
+          // configured APP_URL — never from client input or the `Host`
+          // header — to prevent verification-link poisoning (CWE-640).
+          const verifyUrl = `${APP_URL}/${input.locale}/verify-email?token=${token}`;
+          await emailService.sendVerificationEmail(input.email, verifyUrl);
         } catch {
           // Email delivery failure is non-fatal: the token is stored and the
           // user can request a resend from /verify-email.

--- a/src/interface-adapters/controllers/auth/request-password-reset.controller.ts
+++ b/src/interface-adapters/controllers/auth/request-password-reset.controller.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
+import { SUPPORTED_LOCALES } from '@/config';
+
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { IRequestPasswordResetUseCase } from '@/src/application/use-cases/auth/request-password-reset.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
 const inputSchema = z.object({
   email: z.string().email(),
-  resetBaseUrl: z.string().url(),
+  locale: z.enum(SUPPORTED_LOCALES),
 });
 
 export type IRequestPasswordResetController = ReturnType<
@@ -26,7 +28,7 @@ export const requestPasswordResetController =
         if (error) {
           throw new InputParseError('Invalid data', { cause: error });
         }
-        await requestPasswordResetUseCase(data.email, data.resetBaseUrl);
+        await requestPasswordResetUseCase(data.email, data.locale);
       }
     );
   };

--- a/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
+++ b/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
@@ -1,12 +1,14 @@
 import { z } from 'zod';
 
+import { SUPPORTED_LOCALES } from '@/config';
+
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { IResendVerificationEmailUseCase } from '@/src/application/use-cases/auth/resend-verification-email.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
 const inputSchema = z.object({
   userId: z.string().min(1),
-  verifyBaseUrl: z.string().url(),
+  locale: z.enum(SUPPORTED_LOCALES),
 });
 
 export type IResendVerificationEmailController = ReturnType<
@@ -26,7 +28,7 @@ export const resendVerificationEmailController =
         if (error) {
           throw new InputParseError('Invalid data', { cause: error });
         }
-        await resendVerificationEmailUseCase(data.userId, data.verifyBaseUrl);
+        await resendVerificationEmailUseCase(data.userId, data.locale);
       }
     );
   };

--- a/src/interface-adapters/controllers/auth/sign-up.controller.ts
+++ b/src/interface-adapters/controllers/auth/sign-up.controller.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { SUPPORTED_LOCALES } from '@/config';
+
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { ISignUpUseCase } from '@/src/application/use-cases/auth/sign-up.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
@@ -9,7 +11,7 @@ const inputSchema = z
     email: z.email(),
     password: z.string().min(6).max(31),
     confirmPassword: z.string().min(6).max(31),
-    verifyBaseUrl: z.string().url(),
+    locale: z.enum(SUPPORTED_LOCALES),
   })
   .superRefine(({ password, confirmPassword }, ctx) => {
     if (confirmPassword !== password) {

--- a/tests/seed.ts
+++ b/tests/seed.ts
@@ -27,6 +27,14 @@ export async function seed() {
       email: 'four@test.com',
       passwordHash: hashSync('password-four', PASSWORD_SALT_ROUNDS),
     },
+    // Dedicated seed user (non-numeric id, out of the '1'-'11' range other
+    // tests dynamically create/consume) for the reset-password session-
+    // revocation test, so it doesn't collide with unrelated test isolation.
+    {
+      id: 'password-reset-seed',
+      email: 'password-reset-seed@test.com',
+      passwordHash: hashSync('password-reset-seed', PASSWORD_SALT_ROUNDS),
+    },
   ]);
   await db.insert(userSettings).values([
     {

--- a/tests/units/application/use-cases/auth/reset-password.use-case.test.ts
+++ b/tests/units/application/use-cases/auth/reset-password.use-case.test.ts
@@ -1,0 +1,65 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { getInjection } from '@/di/container';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+
+const signInUseCase = getInjection('ISignInUseCase');
+const requestPasswordResetUseCase = getInjection(
+  'IRequestPasswordResetUseCase'
+);
+const resetPasswordUseCase = getInjection('IResetPasswordUseCase');
+const sessionsRepository = getInjection('ISessionRepository');
+
+let capturedToken = '';
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockImplementation(async (_url, options) => {
+    const body = options?.body ? String(options.body) : '';
+    const match = body.match(/token=([a-z0-9]+)/);
+    if (match) capturedToken = match[1];
+    return new Response(null, { status: 200 });
+  });
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('revokes every existing session after a successful reset', async () => {
+  const { session: sessionA } = await signInUseCase({
+    email: 'password-reset-seed@test.com',
+    password: 'password-reset-seed',
+  });
+  const { session: sessionB } = await signInUseCase({
+    email: 'password-reset-seed@test.com',
+    password: 'password-reset-seed',
+  });
+
+  await requestPasswordResetUseCase('password-reset-seed@test.com', 'en');
+  expect(capturedToken).not.toBe('');
+
+  await resetPasswordUseCase(capturedToken, 'password-reset-seed-new');
+
+  // Both prior sessions must be gone: forgot-password is an
+  // account-recovery flow and there is no "current" session to spare.
+  await expect(
+    sessionsRepository.getSession(sessionA.id)
+  ).resolves.toBeUndefined();
+  await expect(
+    sessionsRepository.getSession(sessionB.id)
+  ).resolves.toBeUndefined();
+
+  // The new password works.
+  await expect(
+    signInUseCase({
+      email: 'password-reset-seed@test.com',
+      password: 'password-reset-seed-new',
+    })
+  ).resolves.toHaveProperty('session');
+});
+
+it('throws for an invalid or unknown token', async () => {
+  await expect(
+    resetPasswordUseCase('not-a-real-token', 'doesntmatter')
+  ).rejects.toBeInstanceOf(AuthenticationError);
+});

--- a/tests/units/application/use-cases/auth/sign-up.use-case.test.ts
+++ b/tests/units/application/use-cases/auth/sign-up.use-case.test.ts
@@ -5,8 +5,6 @@ import { AuthenticationError } from '@/src/entities/errors/auth';
 
 const signUpUseCase = getInjection('ISignUpUseCase');
 
-const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
-
 beforeAll(() => {
   vi.spyOn(global, 'fetch').mockResolvedValue(
     new Response(null, { status: 200 })
@@ -23,7 +21,7 @@ it('returns session and cookie', async () => {
   const result = await signUpUseCase({
     email: 'new@test.com',
     password: 'password-new',
-    verifyBaseUrl: TEST_VERIFY_BASE_URL,
+    locale: 'en',
   });
   expect(result).toHaveProperty('session');
   expect(result).toHaveProperty('cookie');
@@ -35,7 +33,7 @@ it('throws for invalid input', async () => {
     signUpUseCase({
       email: 'one@test.com',
       password: 'doesntmatter',
-      verifyBaseUrl: TEST_VERIFY_BASE_URL,
+      locale: 'en',
     })
   ).rejects.toBeInstanceOf(AuthenticationError);
 });

--- a/tests/units/application/use-cases/users/update-user-password.use-case.test.ts
+++ b/tests/units/application/use-cases/users/update-user-password.use-case.test.ts
@@ -7,8 +7,6 @@ const signInUseCase = getInjection('ISignInUseCase');
 const signUpUseCase = getInjection('ISignUpUseCase');
 const updateUserPasswordUseCase = getInjection('IUpdateUserPasswordUseCase');
 
-const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
-
 beforeAll(() => {
   vi.spyOn(global, 'fetch').mockResolvedValue(
     new Response(null, { status: 200 })
@@ -23,7 +21,7 @@ it('update user password', async () => {
   const { session, user } = await signUpUseCase({
     email: 'six@test.com',
     password: 'password-six',
-    verifyBaseUrl: TEST_VERIFY_BASE_URL,
+    locale: 'en',
   });
 
   await updateUserPasswordUseCase(
@@ -48,7 +46,7 @@ it('throws authentication error', async () => {
   const { session, user } = await signUpUseCase({
     email: 'seven@test.com',
     password: 'password-seven',
-    verifyBaseUrl: TEST_VERIFY_BASE_URL,
+    locale: 'en',
   });
   await expect(
     updateUserPasswordUseCase(

--- a/tests/units/interface-adapters/controllers/auth/sign-up.controller.test.ts
+++ b/tests/units/interface-adapters/controllers/auth/sign-up.controller.test.ts
@@ -8,8 +8,6 @@ import { InputParseError } from '@/src/entities/errors/common';
 
 const signUpController = getInjection('ISignUpController');
 
-const TEST_VERIFY_BASE_URL = 'http://localhost:3000/en/verify-email';
-
 beforeAll(() => {
   vi.spyOn(global, 'fetch').mockResolvedValue(
     new Response(null, { status: 200 })
@@ -27,7 +25,7 @@ it('returns cookie', async () => {
     email: 'newUser@test.com',
     password: 'password',
     confirmPassword: 'password',
-    verifyBaseUrl: TEST_VERIFY_BASE_URL,
+    locale: 'en',
   });
 
   expect(user).toBeDefined();
@@ -47,7 +45,7 @@ it('throws for invalid input', async () => {
       email: 'no',
       password: 'no',
       confirmPassword: 'nah',
-      verifyBaseUrl: TEST_VERIFY_BASE_URL,
+      locale: 'en',
     })
   ).rejects.toBeInstanceOf(InputParseError);
 
@@ -57,7 +55,18 @@ it('throws for invalid input', async () => {
       email: 'nikolovlazar',
       password: 'password',
       confirmPassword: 'passwords',
-      verifyBaseUrl: TEST_VERIFY_BASE_URL,
+      locale: 'en',
+    })
+  ).rejects.toBeInstanceOf(InputParseError);
+
+  // unsupported locale
+  await expect(
+    signUpController({
+      email: 'someone@test.com',
+      password: 'password',
+      confirmPassword: 'password',
+      // @ts-expect-error intentionally invalid locale
+      locale: 'fr',
     })
   ).rejects.toBeInstanceOf(InputParseError);
 });
@@ -68,7 +77,7 @@ it('throws for existing email', async () => {
       email: 'one@test.com',
       password: 'doesntmatter',
       confirmPassword: 'doesntmatter',
-      verifyBaseUrl: TEST_VERIFY_BASE_URL,
+      locale: 'en',
     })
   ).rejects.toBeInstanceOf(AuthenticationError);
 });


### PR DESCRIPTION
## Summary
Fixes two issues from a security review of the auth flows:

- **CRITICAL — Host header injection → password-reset/email-verification link poisoning (CWE-640).** `app/actions/auth/index.ts` built the reset/verify links emailed to users from the incoming `Host` header, which is attacker-controlled. An attacker could forge `Host` on a request targeting a victim's email, causing the victim to receive a legitimate-looking email containing a valid single-use token embedded in a link to an attacker-controlled domain. Fixed by adding a trusted, server-configured `APP_URL` (`config.ts`, required in production, defaults to `localhost` in dev/test) plus a `SUPPORTED_LOCALES` allowlist, and removing the client/action-supplied `resetBaseUrl`/`verifyBaseUrl` parameters entirely from the request-password-reset, resend-verification-email, and sign-up use-cases/controllers in favor of a validated `locale` enum. Links are now always built server-side from `APP_URL` + `locale`.
- **HIGH — forgot-password reset didn't revoke existing sessions.** PR #37 added session revocation on in-app password change and on completed email change, but missed the forgot-password/account-recovery flow — the case that matters most, since it's used specifically when a user suspects their credentials were compromised. `reset-password.use-case.ts` now calls `sessionsRepository.deleteUserSession` after a successful reset, invalidating every session for that user (there's no "current" session to spare in this flow, unlike the authenticated password-change case).

Also wires `APP_URL=http://localhost:3000` into CI (`test.yml`), since the e2e/lighthouse jobs run `next build`/`next start`, which force `NODE_ENV=production` and would otherwise fail fast on the new required env var.

**Deliberately out of scope** (reported separately, not fixed here): missing rate limiting on auth endpoints, missing security headers in `next.config.ts`, and dev-only transitive `npm audit` findings (`handlebars`/`tmp` via `eslint-plugin-boundaries` and `@lhci/cli`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 132/132 passing, including new `reset-password.use-case.test.ts` covering multi-session revocation and invalid-token rejection
- [x] `npx prettier --check` on all touched files
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for locale-aware email links across sign-up, password reset, and verification flows.
  * Introduced a trusted application URL setting for building user-facing links.

* **Bug Fixes**
  * Improved link safety by avoiding fallbacks to request-derived host values.
  * Password resets now revoke existing sessions after a successful reset.

* **Chores**
  * Updated environment and CI defaults to include the new application URL setting.
  * Adjusted test coverage and sample data to match the updated sign-in and recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->