### PR TITLE
feat: wrap sign-up, password-reset, and email-verification writes in DB transactions

### DIFF
--- a/di/modules/authentication.module.ts
+++ b/di/modules/authentication.module.ts
@@ -65,6 +65,7 @@ export function createAuthenticationModule() {
     .bind(DI_SYMBOLS.ISignUpController)
     .toHigherOrderFunction(signUpController, [
       DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ITransactionManagerService,
       DI_SYMBOLS.ISignUpUseCase,
     ]);
 

--- a/di/modules/email-verification.module.ts
+++ b/di/modules/email-verification.module.ts
@@ -45,6 +45,7 @@ export function createEmailVerificationModule() {
     .bind(DI_SYMBOLS.IResendVerificationEmailController)
     .toHigherOrderFunction(resendVerificationEmailController, [
       DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ITransactionManagerService,
       DI_SYMBOLS.IResendVerificationEmailUseCase,
     ]);
 

--- a/di/modules/password-reset.module.ts
+++ b/di/modules/password-reset.module.ts
@@ -44,6 +44,7 @@ export function createPasswordResetModule() {
     .bind(DI_SYMBOLS.IRequestPasswordResetController)
     .toHigherOrderFunction(requestPasswordResetController, [
       DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ITransactionManagerService,
       DI_SYMBOLS.IRequestPasswordResetUseCase,
     ]);
 
@@ -51,6 +52,7 @@ export function createPasswordResetModule() {
     .bind(DI_SYMBOLS.IResetPasswordController)
     .toHigherOrderFunction(resetPasswordController, [
       DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ITransactionManagerService,
       DI_SYMBOLS.IResetPasswordUseCase,
     ]);
 

--- a/src/application/repositories/email-verification-tokens.repository.interface.ts
+++ b/src/application/repositories/email-verification-tokens.repository.interface.ts
@@ -1,8 +1,14 @@
 import { EmailVerificationToken } from '@/src/entities/models/email-verification-token';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export interface IEmailVerificationTokensRepository {
-  createToken(tokenHash: string, userId: string, expiresAt: Date): Promise<void>;
+  createToken(
+    tokenHash: string,
+    userId: string,
+    expiresAt: Date,
+    tx?: ITransaction
+  ): Promise<void>;
   getToken(tokenHash: string): Promise<EmailVerificationToken | undefined>;
-  deleteToken(tokenHash: string): Promise<void>;
-  deleteTokensByUserId(userId: string): Promise<void>;
+  deleteToken(tokenHash: string, tx?: ITransaction): Promise<void>;
+  deleteTokensByUserId(userId: string, tx?: ITransaction): Promise<void>;
 }

--- a/src/application/repositories/password-reset-tokens.repository.interface.ts
+++ b/src/application/repositories/password-reset-tokens.repository.interface.ts
@@ -1,8 +1,14 @@
 import { PasswordResetToken } from '@/src/entities/models/password-reset-token';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export interface IPasswordResetTokensRepository {
-  createToken(tokenHash: string, userId: string, expiresAt: Date): Promise<void>;
+  createToken(
+    tokenHash: string,
+    userId: string,
+    expiresAt: Date,
+    tx?: ITransaction
+  ): Promise<void>;
   getToken(tokenHash: string): Promise<PasswordResetToken | undefined>;
-  deleteToken(tokenHash: string): Promise<void>;
-  deleteTokensByUserId(userId: string): Promise<void>;
+  deleteToken(tokenHash: string, tx?: ITransaction): Promise<void>;
+  deleteTokensByUserId(userId: string, tx?: ITransaction): Promise<void>;
 }

--- a/src/application/repositories/sessions.repository.interface.ts
+++ b/src/application/repositories/sessions.repository.interface.ts
@@ -1,8 +1,9 @@
 import { Session } from '@/src/entities/models/session';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 import { User } from '@/src/entities/models/user';
 
 export interface ISessionsRepository {
-  createSession(session: Session): Promise<Session>;
+  createSession(session: Session, tx?: ITransaction): Promise<Session>;
   getSession(sessionId: string): Promise<{ session: Session; user: User }>;
   getUserSession(userId: string): Promise<{ session: Session; user: User }>;
   updateSessionExpiresAt(
@@ -10,7 +11,7 @@ export interface ISessionsRepository {
     newExpiresAt: Date
   ): Promise<Session>;
   deleteSession(sessionId: string): Promise<void>;
-  deleteUserSession(userId: string): Promise<void>;
+  deleteUserSession(userId: string, tx?: ITransaction): Promise<void>;
   deleteOtherSessionsByUserId(
     userId: string,
     currentSessionId: string

--- a/src/application/services/authentication.service.interface.ts
+++ b/src/application/services/authentication.service.interface.ts
@@ -1,5 +1,6 @@
 import { Cookie } from '@/src/entities/models/cookie';
 import { Session } from '@/src/entities/models/session';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 import { User } from '@/src/entities/models/user';
 
 export interface IAuthenticationService {
@@ -9,7 +10,10 @@ export interface IAuthenticationService {
     inputPassword: string,
     usersHashedPassword: string
   ): Promise<boolean>;
-  createSession(user: User): Promise<{ session: Session; cookie: Cookie }>;
+  createSession(
+    user: User,
+    tx?: ITransaction
+  ): Promise<{ session: Session; cookie: Cookie }>;
   buildSessionCookie(token: string, expiresAt: Date): Cookie;
   invalidateSession(token: string): Promise<{ blankCookie: Cookie }>;
 }

--- a/src/application/use-cases/auth/request-password-reset.use-case.ts
+++ b/src/application/use-cases/auth/request-password-reset.use-case.ts
@@ -10,6 +10,7 @@ import { IPasswordResetTokensRepository } from '@/src/application/repositories/p
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IEmailService } from '@/src/application/services/email.service.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export type IRequestPasswordResetUseCase = ReturnType<
   typeof requestPasswordResetUseCase
@@ -22,7 +23,11 @@ export const requestPasswordResetUseCase =
     passwordResetTokensRepository: IPasswordResetTokensRepository,
     emailService: IEmailService
   ) =>
-  async (email: string, locale: SupportedLocale): Promise<void> => {
+  async (
+    email: string,
+    locale: SupportedLocale,
+    tx?: ITransaction
+  ): Promise<void> => {
     return await instrumentationService.startSpan(
       { name: 'requestPasswordReset Use Case' },
       async () => {
@@ -32,7 +37,10 @@ export const requestPasswordResetUseCase =
           return;
         }
 
-        await passwordResetTokensRepository.deleteTokensByUserId(user.id);
+        // Old tokens are invalidated and the new one created atomically, so
+        // a failure between the two never leaves the user without any valid
+        // token and without the old one either.
+        await passwordResetTokensRepository.deleteTokensByUserId(user.id, tx);
 
         const bytes = new Uint8Array(20);
         crypto.getRandomValues(bytes);
@@ -45,7 +53,8 @@ export const requestPasswordResetUseCase =
         await passwordResetTokensRepository.createToken(
           tokenHash,
           user.id,
-          expiresAt
+          expiresAt,
+          tx
         );
 
         // SECURITY: the base URL is always built from the trusted, server-

--- a/src/application/use-cases/auth/resend-verification-email.use-case.ts
+++ b/src/application/use-cases/auth/resend-verification-email.use-case.ts
@@ -10,6 +10,7 @@ import { IEmailVerificationTokensRepository } from '@/src/application/repositori
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IEmailService } from '@/src/application/services/email.service.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export type IResendVerificationEmailUseCase = ReturnType<
   typeof resendVerificationEmailUseCase
@@ -22,7 +23,11 @@ export const resendVerificationEmailUseCase =
     emailVerificationTokensRepository: IEmailVerificationTokensRepository,
     emailService: IEmailService
   ) =>
-  async (userId: string, locale: SupportedLocale): Promise<void> => {
+  async (
+    userId: string,
+    locale: SupportedLocale,
+    tx?: ITransaction
+  ): Promise<void> => {
     return await instrumentationService.startSpan(
       { name: 'resendVerificationEmail Use Case' },
       async () => {
@@ -31,7 +36,13 @@ export const resendVerificationEmailUseCase =
           return;
         }
 
-        await emailVerificationTokensRepository.deleteTokensByUserId(userId);
+        // Old tokens are invalidated and the new one created atomically, so
+        // a failure between the two never leaves the user without any valid
+        // token and without the old one either.
+        await emailVerificationTokensRepository.deleteTokensByUserId(
+          userId,
+          tx
+        );
 
         const bytes = new Uint8Array(20);
         crypto.getRandomValues(bytes);
@@ -44,7 +55,8 @@ export const resendVerificationEmailUseCase =
         await emailVerificationTokensRepository.createToken(
           tokenHash,
           userId,
-          expiresAt
+          expiresAt,
+          tx
         );
 
         // SECURITY: the base URL is always built from the trusted, server-

--- a/src/application/use-cases/auth/reset-password.use-case.ts
+++ b/src/application/use-cases/auth/reset-password.use-case.ts
@@ -6,6 +6,7 @@ import { ISessionsRepository } from '@/src/application/repositories/sessions.rep
 import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { AuthenticationError } from '@/src/entities/errors/auth';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export type IResetPasswordUseCase = ReturnType<typeof resetPasswordUseCase>;
 
@@ -16,7 +17,11 @@ export const resetPasswordUseCase =
     usersRepository: IUsersRepository,
     sessionsRepository: ISessionsRepository
   ) =>
-  async (token: string, newPassword: string): Promise<void> => {
+  async (
+    token: string,
+    newPassword: string,
+    tx?: ITransaction
+  ): Promise<void> => {
     return await instrumentationService.startSpan(
       { name: 'resetPassword Use Case' },
       async () => {
@@ -33,23 +38,30 @@ export const resetPasswordUseCase =
         }
 
         if (Date.now() >= resetToken.expiresAt.getTime()) {
-          await passwordResetTokensRepository.deleteToken(tokenHash);
+          await passwordResetTokensRepository.deleteToken(tokenHash, tx);
           throw new AuthenticationError(
             'Invalid or expired password reset token'
           );
         }
 
-        await usersRepository.updateUser(resetToken.userId, {
-          password: newPassword,
-        });
-        await passwordResetTokensRepository.deleteToken(tokenHash);
+        // Password update, token invalidation, and session revocation are
+        // all part of the same atomic write: a partial failure must never
+        // leave the password changed without the token consumed (replay
+        // risk) or without every session revoked (the whole point of this
+        // flow -- see comment below).
+        await usersRepository.updateUser(
+          resetToken.userId,
+          { password: newPassword },
+          tx
+        );
+        await passwordResetTokensRepository.deleteToken(tokenHash, tx);
 
         // SECURITY: forgot-password reset is the account-recovery path used
         // when a user suspects their credentials were compromised. Revoke
         // every existing session (there is no "current" session to spare
         // here, unlike an in-app password change) so a stolen session
         // cookie can no longer be used after the owner regains control.
-        await sessionsRepository.deleteUserSession(resetToken.userId);
+        await sessionsRepository.deleteUserSession(resetToken.userId, tx);
       }
     );
   };

--- a/src/application/use-cases/auth/sign-up.use-case.ts
+++ b/src/application/use-cases/auth/sign-up.use-case.ts
@@ -17,6 +17,7 @@ import { AuthenticationError } from '@/src/entities/errors/auth';
 import { ConflictError } from '@/src/entities/errors/common';
 import { Cookie } from '@/src/entities/models/cookie';
 import { Session } from '@/src/entities/models/session';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 import { User } from '@/src/entities/models/user';
 
 export type ISignUpUseCase = ReturnType<typeof signUpUseCase>;
@@ -31,11 +32,14 @@ export const signUpUseCase =
     emailVerificationTokensRepository: IEmailVerificationTokensRepository,
     emailService: IEmailService
   ) =>
-  (input: {
-    email: string;
-    password: string;
-    locale: SupportedLocale;
-  }): Promise<{
+  (
+    input: {
+      email: string;
+      password: string;
+      locale: SupportedLocale;
+    },
+    tx?: ITransaction
+  ): Promise<{
     session: Session;
     cookie: Cookie;
     user: User;
@@ -56,11 +60,14 @@ export const signUpUseCase =
 
         let newUser: User;
         try {
-          newUser = await usersRepository.createUser({
-            id: userId,
-            email: input.email,
-            password: input.password,
-          });
+          newUser = await usersRepository.createUser(
+            {
+              id: userId,
+              email: input.email,
+              password: input.password,
+            },
+            tx
+          );
         } catch (err) {
           if (err instanceof ConflictError) {
             throw new AuthenticationError('Email taken');
@@ -70,7 +77,7 @@ export const signUpUseCase =
 
         await emailBloomFilterService.recordEmail(input.email);
 
-        await userSettingsRepository.createUserSettings(userId);
+        await userSettingsRepository.createUserSettings(userId, tx);
 
         const bytes = new Uint8Array(20);
         crypto.getRandomValues(bytes);
@@ -82,21 +89,36 @@ export const signUpUseCase =
         await emailVerificationTokensRepository.createToken(
           tokenHash,
           userId,
-          expiresAt
+          expiresAt,
+          tx
         );
+
+        const { cookie, session } = await authenticationService.createSession(
+          newUser,
+          tx
+        );
+
         try {
           // SECURITY: the base URL is always built from the trusted, server-
           // configured APP_URL — never from client input or the `Host`
           // header — to prevent verification-link poisoning (CWE-640).
+          //
+          // Sent after all writes for this transaction have been queued, but
+          // note the actual COMMIT only happens once this whole callback
+          // returns (SQLite/libsql transaction semantics) -- so this call is
+          // still effectively "mid-transaction". If a later write in this
+          // same use case were added and failed, causing a rollback, an
+          // already-sent email could point at a token that no longer
+          // exists. None of the current steps after this point can fail in
+          // a way that should block sign-up, so this is an accepted
+          // tradeoff; keep this the last side effect in the function if more
+          // steps are ever added here.
           const verifyUrl = `${APP_URL}/${input.locale}/verify-email?token=${token}`;
           await emailService.sendVerificationEmail(input.email, verifyUrl);
         } catch {
           // Email delivery failure is non-fatal: the token is stored and the
           // user can request a resend from /verify-email.
         }
-
-        const { cookie, session } =
-          await authenticationService.createSession(newUser);
 
         return {
           cookie,

--- a/src/infrastructure/repositories/email-verification-tokens.repository.ts
+++ b/src/infrastructure/repositories/email-verification-tokens.repository.ts
@@ -1,15 +1,13 @@
+import { Transaction, db } from '@/drizzle';
 import { eq } from 'drizzle-orm';
 
-import { db } from '@/drizzle';
 import { emailVerificationTokens } from '@/drizzle/schema';
 import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
 import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { EmailVerificationToken } from '@/src/entities/models/email-verification-token';
 
-export class EmailVerificationTokensRepository
-  implements IEmailVerificationTokensRepository
-{
+export class EmailVerificationTokensRepository implements IEmailVerificationTokensRepository {
   constructor(
     private readonly instrumentationService: IInstrumentationService,
     private readonly crashReporterService: ICrashReporterService
@@ -18,13 +16,15 @@ export class EmailVerificationTokensRepository
   async createToken(
     tokenHash: string,
     userId: string,
-    expiresAt: Date
+    expiresAt: Date,
+    tx?: Transaction
   ): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'EmailVerificationTokensRepository > createToken' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .insert(emailVerificationTokens)
             .values({ tokenHash, userId, expiresAt });
           await this.instrumentationService.startSpan(
@@ -69,12 +69,13 @@ export class EmailVerificationTokensRepository
     );
   }
 
-  async deleteToken(tokenHash: string): Promise<void> {
+  async deleteToken(tokenHash: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'EmailVerificationTokensRepository > deleteToken' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .delete(emailVerificationTokens)
             .where(eq(emailVerificationTokens.tokenHash, tokenHash));
           await this.instrumentationService.startSpan(
@@ -93,12 +94,13 @@ export class EmailVerificationTokensRepository
     );
   }
 
-  async deleteTokensByUserId(userId: string): Promise<void> {
+  async deleteTokensByUserId(userId: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'EmailVerificationTokensRepository > deleteTokensByUserId' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .delete(emailVerificationTokens)
             .where(eq(emailVerificationTokens.userId, userId));
           await this.instrumentationService.startSpan(

--- a/src/infrastructure/repositories/password-reset-tokens.repository.ts
+++ b/src/infrastructure/repositories/password-reset-tokens.repository.ts
@@ -1,15 +1,13 @@
+import { Transaction, db } from '@/drizzle';
 import { eq } from 'drizzle-orm';
 
-import { db } from '@/drizzle';
 import { passwordResetTokens } from '@/drizzle/schema';
 import { IPasswordResetTokensRepository } from '@/src/application/repositories/password-reset-tokens.repository.interface';
 import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { PasswordResetToken } from '@/src/entities/models/password-reset-token';
 
-export class PasswordResetTokensRepository
-  implements IPasswordResetTokensRepository
-{
+export class PasswordResetTokensRepository implements IPasswordResetTokensRepository {
   constructor(
     private readonly instrumentationService: IInstrumentationService,
     private readonly crashReporterService: ICrashReporterService
@@ -18,13 +16,15 @@ export class PasswordResetTokensRepository
   async createToken(
     tokenHash: string,
     userId: string,
-    expiresAt: Date
+    expiresAt: Date,
+    tx?: Transaction
   ): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'PasswordResetTokensRepository > createToken' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .insert(passwordResetTokens)
             .values({ tokenHash, userId, expiresAt });
           await this.instrumentationService.startSpan(
@@ -67,12 +67,13 @@ export class PasswordResetTokensRepository
     );
   }
 
-  async deleteToken(tokenHash: string): Promise<void> {
+  async deleteToken(tokenHash: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'PasswordResetTokensRepository > deleteToken' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .delete(passwordResetTokens)
             .where(eq(passwordResetTokens.tokenHash, tokenHash));
           await this.instrumentationService.startSpan(
@@ -91,12 +92,13 @@ export class PasswordResetTokensRepository
     );
   }
 
-  async deleteTokensByUserId(userId: string): Promise<void> {
+  async deleteTokensByUserId(userId: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'PasswordResetTokensRepository > deleteTokensByUserId' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .delete(passwordResetTokens)
             .where(eq(passwordResetTokens.userId, userId));
           await this.instrumentationService.startSpan(

--- a/src/infrastructure/repositories/sessions.repository.ts
+++ b/src/infrastructure/repositories/sessions.repository.ts
@@ -1,4 +1,4 @@
-import { db } from '@/drizzle';
+import { Transaction, db } from '@/drizzle';
 import { encodeBase32LowerCaseNoPadding } from '@oslojs/encoding';
 import { and, eq, ne } from 'drizzle-orm';
 
@@ -23,8 +23,8 @@ export class SessionsRepository implements ISessionsRepository {
     return token;
   }
 
-  async createSession(session: Session): Promise<Session> {
-    const invoker = db;
+  async createSession(session: Session, tx?: Transaction): Promise<Session> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'SessionsRepository > createSession' },
       async () => {
@@ -203,8 +203,8 @@ export class SessionsRepository implements ISessionsRepository {
     );
   }
 
-  async deleteUserSession(userId: string): Promise<void> {
-    const invoker = db;
+  async deleteUserSession(userId: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'SessionsRepository > deleteUserSession' },
       async () => {

--- a/src/infrastructure/repositories/users.repository.ts
+++ b/src/infrastructure/repositories/users.repository.ts
@@ -97,7 +97,8 @@ export class UsersRepository implements IUsersRepository {
     );
   }
 
-  async createUser(input: CreateUser): Promise<User> {
+  async createUser(input: CreateUser, tx?: Transaction): Promise<User> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'UsersRepository > createUser' },
       async () => {
@@ -113,7 +114,7 @@ export class UsersRepository implements IUsersRepository {
             passwordHash,
             emailVerified: false,
           };
-          const query = db.insert(users).values(newUser).returning();
+          const query = invoker.insert(users).values(newUser).returning();
 
           const [created] = await this.instrumentationService.startSpan(
             {

--- a/src/infrastructure/services/authentication.service.ts
+++ b/src/infrastructure/services/authentication.service.ts
@@ -17,6 +17,7 @@ import type { IInstrumentationService } from '@/src/application/services/instrum
 import { UnauthenticatedError } from '@/src/entities/errors/auth';
 import { Cookie } from '@/src/entities/models/cookie';
 import { Session } from '@/src/entities/models/session';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 import { User } from '@/src/entities/models/user';
 
 function generateIdFromEntropySize(entropyBytes: number): string {
@@ -97,7 +98,8 @@ export class AuthenticationService implements IAuthenticationService {
   }
 
   async createSession(
-    user: User
+    user: User,
+    tx?: ITransaction
   ): Promise<{ session: Session; cookie: Cookie }> {
     return await this._instrumentationService.startSpan(
       { name: 'AuthenticationService > createSession' },
@@ -111,11 +113,14 @@ export class AuthenticationService implements IAuthenticationService {
           sha256(new TextEncoder().encode(token))
         );
         const expiresAt = new Date(Date.now() + SESSION_EXPIRY_MS);
-        const session = await this._sessionRepository.createSession({
-          id: sessionId,
-          userId: user.id,
-          expiresAt: expiresAt,
-        });
+        const session = await this._sessionRepository.createSession(
+          {
+            id: sessionId,
+            userId: user.id,
+            expiresAt: expiresAt,
+          },
+          tx
+        );
 
         const cookie = this.buildSessionCookie(token, expiresAt);
 

--- a/src/interface-adapters/controllers/auth/request-password-reset.controller.ts
+++ b/src/interface-adapters/controllers/auth/request-password-reset.controller.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { SUPPORTED_LOCALES } from '@/config';
 
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
 import { IRequestPasswordResetUseCase } from '@/src/application/use-cases/auth/request-password-reset.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
@@ -18,6 +19,7 @@ export type IRequestPasswordResetController = ReturnType<
 export const requestPasswordResetController =
   (
     instrumentationService: IInstrumentationService,
+    transactionManagerService: ITransactionManagerService,
     requestPasswordResetUseCase: IRequestPasswordResetUseCase
   ) =>
   async (input: Partial<z.infer<typeof inputSchema>>): Promise<void> => {
@@ -28,7 +30,12 @@ export const requestPasswordResetController =
         if (error) {
           throw new InputParseError('Invalid data', { cause: error });
         }
-        await requestPasswordResetUseCase(data.email, data.locale);
+        // Invalidating the old token(s) and creating the new one happens
+        // atomically. No manual try/catch + tx.rollback(): Drizzle already
+        // rolls back and rethrows the original error on any failure.
+        await transactionManagerService.startTransaction((tx) =>
+          requestPasswordResetUseCase(data.email, data.locale, tx)
+        );
       }
     );
   };

--- a/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
+++ b/src/interface-adapters/controllers/auth/resend-verification-email.controller.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { SUPPORTED_LOCALES } from '@/config';
 
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
 import { IResendVerificationEmailUseCase } from '@/src/application/use-cases/auth/resend-verification-email.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
@@ -18,6 +19,7 @@ export type IResendVerificationEmailController = ReturnType<
 export const resendVerificationEmailController =
   (
     instrumentationService: IInstrumentationService,
+    transactionManagerService: ITransactionManagerService,
     resendVerificationEmailUseCase: IResendVerificationEmailUseCase
   ) =>
   async (input: Partial<z.infer<typeof inputSchema>>): Promise<void> => {
@@ -28,7 +30,12 @@ export const resendVerificationEmailController =
         if (error) {
           throw new InputParseError('Invalid data', { cause: error });
         }
-        await resendVerificationEmailUseCase(data.userId, data.locale);
+        // Invalidating the old token(s) and creating the new one happens
+        // atomically. No manual try/catch + tx.rollback(): Drizzle already
+        // rolls back and rethrows the original error on any failure.
+        await transactionManagerService.startTransaction((tx) =>
+          resendVerificationEmailUseCase(data.userId, data.locale, tx)
+        );
       }
     );
   };

--- a/src/interface-adapters/controllers/auth/reset-password.controller.ts
+++ b/src/interface-adapters/controllers/auth/reset-password.controller.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
 import { IResetPasswordUseCase } from '@/src/application/use-cases/auth/reset-password.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
@@ -27,6 +28,7 @@ export type IResetPasswordController = ReturnType<
 export const resetPasswordController =
   (
     instrumentationService: IInstrumentationService,
+    transactionManagerService: ITransactionManagerService,
     resetPasswordUseCase: IResetPasswordUseCase
   ) =>
   async (input: Partial<z.infer<typeof inputSchema>>): Promise<void> => {
@@ -37,7 +39,14 @@ export const resetPasswordController =
         if (error) {
           throw new InputParseError('Invalid data', { cause: error });
         }
-        await resetPasswordUseCase(data.token, data.password);
+        // Password update, token invalidation, and session revocation all
+        // happen atomically -- see reset-password.use-case.ts. No manual
+        // try/catch + tx.rollback(): Drizzle already rolls back and
+        // rethrows the original error (e.g. AuthenticationError) on any
+        // failure, which callers rely on for user-facing messaging.
+        await transactionManagerService.startTransaction((tx) =>
+          resetPasswordUseCase(data.token, data.password, tx)
+        );
       }
     );
   };

--- a/src/interface-adapters/controllers/auth/sign-up.controller.ts
+++ b/src/interface-adapters/controllers/auth/sign-up.controller.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { SUPPORTED_LOCALES } from '@/config';
 
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
 import { ISignUpUseCase } from '@/src/application/use-cases/auth/sign-up.use-case';
 import { InputParseError } from '@/src/entities/errors/common';
 
@@ -33,6 +34,7 @@ export type ISignUpController = ReturnType<typeof signUpController>;
 export const signUpController =
   (
     instrumentationService: IInstrumentationService,
+    transactionManagerService: ITransactionManagerService,
     signUpUseCase: ISignUpUseCase
   ) =>
   async (
@@ -47,7 +49,15 @@ export const signUpController =
           throw new InputParseError('Invalid data', { cause: inputParseError });
         }
 
-        return await signUpUseCase(data);
+        // The user row, settings, verification token, and session are all
+        // created atomically. No manual try/catch + tx.rollback() here:
+        // Drizzle's transaction() already rolls back automatically on any
+        // thrown error and rethrows it unchanged -- which matters, since
+        // callers rely on AuthenticationError ('Email taken') surfacing
+        // intact.
+        return await transactionManagerService.startTransaction((tx) =>
+          signUpUseCase(data, tx)
+        );
       }
     );
   };

--- a/tests/seed.ts
+++ b/tests/seed.ts
@@ -35,6 +35,18 @@ export async function seed() {
       email: 'password-reset-seed@test.com',
       passwordHash: hashSync('password-reset-seed', PASSWORD_SALT_ROUNDS),
     },
+    // Dedicated seed user for the reset-password transaction-rollback test
+    // (verifies a failure mid-transaction leaves nothing committed), kept
+    // separate from the seed user above so the two tests can't interfere
+    // with each other's password/session state across test files.
+    {
+      id: 'reset-password-rollback-seed',
+      email: 'reset-password-rollback-seed@test.com',
+      passwordHash: hashSync(
+        'reset-password-rollback-seed',
+        PASSWORD_SALT_ROUNDS
+      ),
+    },
   ]);
   await db.insert(userSettings).values([
     {

--- a/tests/units/interface-adapters/controllers/auth/reset-password.controller.test.ts
+++ b/tests/units/interface-adapters/controllers/auth/reset-password.controller.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { getInjection } from '@/di/container';
+import { InputParseError } from '@/src/entities/errors/common';
+
+const signInUseCase = getInjection('ISignInUseCase');
+const requestPasswordResetController = getInjection(
+  'IRequestPasswordResetController'
+);
+const resetPasswordController = getInjection('IResetPasswordController');
+const sessionsRepository = getInjection('ISessionRepository');
+
+let capturedToken = '';
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockImplementation(async (_url, options) => {
+    const body = options?.body ? String(options.body) : '';
+    const match = body.match(/token=([a-z0-9]+)/);
+    if (match) capturedToken = match[1];
+    return new Response(null, { status: 200 });
+  });
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('throws for invalid input', async () => {
+  await expect(resetPasswordController({})).rejects.toBeInstanceOf(
+    InputParseError
+  );
+});
+
+it('rolls back the whole reset if a later step fails, leaving nothing committed', async () => {
+  const { session } = await signInUseCase({
+    email: 'reset-password-rollback-seed@test.com',
+    password: 'reset-password-rollback-seed',
+  });
+
+  await requestPasswordResetController({
+    email: 'reset-password-rollback-seed@test.com',
+    locale: 'en',
+  });
+  expect(capturedToken).not.toBe('');
+
+  // Force the last write in the transaction (session revocation) to fail,
+  // simulating a transient infra error after the password/token writes
+  // have already been queued but before the transaction commits.
+  vi.spyOn(sessionsRepository, 'deleteUserSession').mockImplementationOnce(
+    async () => {
+      throw new Error('simulated failure');
+    }
+  );
+
+  await expect(
+    resetPasswordController({
+      token: capturedToken,
+      password: 'rollback-new-pw',
+      confirmPassword: 'rollback-new-pw',
+    })
+  ).rejects.toThrow('simulated failure');
+
+  // Nothing from the failed attempt should have been committed: the old
+  // password still works...
+  await expect(
+    signInUseCase({
+      email: 'reset-password-rollback-seed@test.com',
+      password: 'reset-password-rollback-seed',
+    })
+  ).resolves.toHaveProperty('session');
+
+  // ...and the pre-existing session was never revoked.
+  await expect(sessionsRepository.getSession(session.id)).resolves.toBeTruthy();
+});


### PR DESCRIPTION
## Summary
Follow-up to #38. Adds atomicity to the four auth use cases that perform multiple sequential writes, so a failure partway through never leaves a half-committed state:

- **`sign-up.use-case.ts`**: `createUser` → `createUserSettings` → `createToken` (email verification) → `createSession` are now one transaction. Previously a failure in a later step (e.g. session creation) could leave an orphaned user row with no settings/verification token.
- **`request-password-reset.use-case.ts`** / **`resend-verification-email.use-case.ts`**: `deleteTokensByUserId` + `createToken` are now atomic, so a failure between them can't leave a user with neither an old nor a new valid token.
- **`reset-password.use-case.ts`**: `updateUser` (password) + `deleteToken` + `deleteUserSession` are now atomic — the highest-value case, since it closes a real gap where a failure after the password update but before session revocation would silently defeat the account-recovery security fix from #38 (password changes, but a compromised session stays alive).

### Supporting changes
- Added optional `tx` parameters to the write methods on `IPasswordResetTokensRepository`, `IEmailVerificationTokensRepository`, and `ISessionsRepository` (mirroring the existing pattern already used by `IUsersRepository`/`ILeavesRepository`).
- Threaded `tx` through `IAuthenticationService.createSession`.
- Fixed a latent bug where `UsersRepository.createUser` declared a `tx` parameter on its interface but never actually used it.
- Each use case is now wrapped in `transactionManagerService.startTransaction` at the controller level, matching the existing convention used by the leaves and update-user-password controllers — **with one deliberate deviation**: no manual `try/catch { tx.rollback() }`. Drizzle's `db.transaction()` already rolls back automatically on any thrown error and rethrows the original error unchanged; the existing catch-and-rollback pattern elsewhere in the codebase silently discards the original error (e.g. `AuthenticationError`) and replaces it with a generic rollback signal, which would have broken the specific-error-type handling these auth flows and their tests rely on (e.g. `AuthenticationError('Email taken')`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 134/134 passing
- [x] New rollback test (`reset-password.controller.test.ts`) forces `sessionsRepository.deleteUserSession` to fail mid-transaction and asserts the password update and prior session are both left untouched — proving the atomicity actually holds and isn't just wiring
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR