### PR TITLE
feat: add account deletion (GDPR/CCPA right to erasure)

### DIFF
--- a/app/[locale]/(private)/users/settings/page.tsx
+++ b/app/[locale]/(private)/users/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
 import { ChangePasswordForm } from '@/app/_components/change-password-form';
+import { DeleteAccountForm } from '@/app/_components/delete-account-form';
 import { SettingsDateForm } from '@/app/_components/settings-date-form';
 import { Separator } from '@/app/_components/ui/separator';
 import { UpdateEmailForm } from '@/app/_components/update-email-form';
@@ -46,6 +47,14 @@ export default async function UserSettingsPage() {
       <Separator />
       <div className="text-lg font-bold">{t('changePassword')}</div>
       <ChangePasswordForm />
+      <Separator />
+      <div className="text-lg font-bold text-destructive">
+        {t('dangerZone')}
+      </div>
+      <p className="text-sm text-muted-foreground">
+        {t('deleteAccountDescription')}
+      </p>
+      <DeleteAccountForm />
     </div>
   );
 }

--- a/app/_components/delete-account-form.tsx
+++ b/app/_components/delete-account-form.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+import { z } from 'zod';
+
+import { Button } from '@/app/_components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/app/_components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/app/_components/ui/form';
+import { Input } from '@/app/_components/ui/input';
+import { userActions } from '@/app/actions';
+
+type DeleteAccountFormProps = React.ComponentPropsWithoutRef<'div'>;
+
+export function DeleteAccountForm({}: DeleteAccountFormProps) {
+  const t = useTranslations();
+  const [loading, startTransition] = useTransition();
+
+  const FormSchema = z.object({
+    currentPassword: z.string().min(1, { message: t('pleaseInput') }),
+  });
+
+  const form = useForm<z.infer<typeof FormSchema>>({
+    resolver: zodResolver(FormSchema),
+    defaultValues: {
+      currentPassword: '',
+    },
+  });
+
+  const onSubmit = async (data: z.infer<typeof FormSchema>) => {
+    if (loading) return;
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set('currentPassword', data.currentPassword);
+      const res = await userActions.deleteAccount(formData);
+      // On success the server action redirects to /sign-in, so there is
+      // nothing further to do here -- only the error path returns.
+      if (res && res.error) {
+        toast.error(res.error);
+      }
+    });
+  };
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button
+          variant="destructive"
+          className="cursor-pointer"
+          data-cy="delete-account-trigger"
+        >
+          {t('deleteAccount')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{t('deleteAccount')}</DialogTitle>
+          <DialogDescription>
+            {t('deleteAccountConfirmation')}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+            <FormField
+              control={form.control}
+              name="currentPassword"
+              render={({ field }) => (
+                <FormItem className="flex flex-col">
+                  <FormLabel>{t('currentPassword')}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder={t('currentPassword')}
+                      value={field.value}
+                      onChange={(e) => field.onChange(e.target.value)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button
+                variant="destructive"
+                type="submit"
+                disabled={loading}
+                data-cy="delete-account-confirm"
+              >
+                {loading && <Loader2 className="animate-spin" />}
+                {t('confirm')}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/actions/users/index.ts
+++ b/app/actions/users/index.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
 
 import { SESSION_COOKIE } from '@/config';
 
@@ -206,6 +207,51 @@ export async function cancelEmailChange() {
             'An error happened. The developers have been notified. Please try again later.',
         };
       }
+    }
+  );
+}
+
+export async function deleteAccount(formData: FormData) {
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.instrumentServerAction(
+    'deleteAccount',
+    { recordResponse: true },
+    async () => {
+      const cookieStore = await cookies();
+      const token = cookieStore.get(SESSION_COOKIE)?.value;
+      const data = Object.fromEntries(formData.entries());
+
+      let blankCookie;
+      try {
+        const deleteAccountController = getInjection(
+          'IDeleteAccountController'
+        );
+        ({ blankCookie } = await deleteAccountController(data, token));
+      } catch (err) {
+        if (err instanceof InputParseError) {
+          return { error: err.message };
+        }
+        if (
+          err instanceof AuthenticationError ||
+          err instanceof UnauthenticatedError
+        ) {
+          return { error: err.message };
+        }
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
+        return {
+          error:
+            'An error happened. The developers have been notified. Please try again later.',
+        };
+      }
+
+      cookieStore.set(
+        blankCookie.name,
+        blankCookie.value,
+        blankCookie.attributes
+      );
+
+      redirect('/sign-in');
     }
   );
 }

--- a/di/modules/users.module.ts
+++ b/di/modules/users.module.ts
@@ -1,10 +1,12 @@
 import { createModule } from '@evyweb/ioctopus';
 
 import { DI_SYMBOLS } from '@/di/types';
+import { deleteAccountUseCase } from '@/src/application/use-cases/users/delete-account.use-case';
 import { getUserUseCase } from '@/src/application/use-cases/users/get-user.use-case';
 import { updateUserPasswordUseCase } from '@/src/application/use-cases/users/update-user-password.use-case';
 import { UsersRepository } from '@/src/infrastructure/repositories/users.repository';
 import { EmailBloomFilterService } from '@/src/infrastructure/services/email-bloom-filter.service';
+import { deleteAccountController } from '@/src/interface-adapters/controllers/users/delete-account.controller';
 import { getSelfUserController } from '@/src/interface-adapters/controllers/users/get-self-user.controller';
 import { updateUserPasswordController } from '@/src/interface-adapters/controllers/users/update-user-password.controller';
 
@@ -41,6 +43,20 @@ export function createUsersModule() {
     ]);
 
   usersModule
+    .bind(DI_SYMBOLS.IDeleteAccountUseCase)
+    .toHigherOrderFunction(deleteAccountUseCase, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IAuthenticationService,
+      DI_SYMBOLS.IUsersRepository,
+      DI_SYMBOLS.ILeavesRepository,
+      DI_SYMBOLS.IUserSettingsRepository,
+      DI_SYMBOLS.IPasswordResetTokensRepository,
+      DI_SYMBOLS.IEmailVerificationTokensRepository,
+      DI_SYMBOLS.IEmailChangeTokensRepository,
+      DI_SYMBOLS.ISessionRepository,
+    ]);
+
+  usersModule
     .bind(DI_SYMBOLS.IGetSelfUserController)
     .toHigherOrderFunction(getSelfUserController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -57,5 +73,15 @@ export function createUsersModule() {
       DI_SYMBOLS.IUpdateUserPasswordUseCase,
       DI_SYMBOLS.ISessionRepository,
     ]);
+
+  usersModule
+    .bind(DI_SYMBOLS.IDeleteAccountController)
+    .toHigherOrderFunction(deleteAccountController, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IAuthenticationService,
+      DI_SYMBOLS.ITransactionManagerService,
+      DI_SYMBOLS.IDeleteAccountUseCase,
+    ]);
+
   return usersModule;
 }

--- a/di/types.ts
+++ b/di/types.ts
@@ -26,6 +26,7 @@ import { IUpdateLeaveUseCase } from '@/src/application/use-cases/leaves/update-l
 import { IGetUserSettingsForUserUseCase } from '@/src/application/use-cases/user-settings/get-user-settings-for-user.use-case';
 import { IUpdateUserSettingsUseCase } from '@/src/application/use-cases/user-settings/update-user-settings.use-case';
 import { ICancelEmailChangeUseCase } from '@/src/application/use-cases/users/cancel-email-change.use-case';
+import { IDeleteAccountUseCase } from '@/src/application/use-cases/users/delete-account.use-case';
 import { IGetPendingEmailChangeUseCase } from '@/src/application/use-cases/users/get-pending-email-change.use-case';
 import { IGetUserUseCase } from '@/src/application/use-cases/users/get-user.use-case';
 import { IRequestEmailChangeUseCase } from '@/src/application/use-cases/users/request-email-change.use-case';
@@ -46,6 +47,7 @@ import { IUpdateLeaveController } from '@/src/interface-adapters/controllers/lea
 import { IGetUserSettingsForUserController } from '@/src/interface-adapters/controllers/user-settings/get-user-settings-for-user.controller';
 import { IUpdateUserSettingsController } from '@/src/interface-adapters/controllers/user-settings/update-user-settings.controller';
 import { ICancelEmailChangeController } from '@/src/interface-adapters/controllers/users/cancel-email-change.controller';
+import { IDeleteAccountController } from '@/src/interface-adapters/controllers/users/delete-account.controller';
 import { IGetPendingEmailChangeController } from '@/src/interface-adapters/controllers/users/get-pending-email-change.controller';
 import { IGetSelfUserController } from '@/src/interface-adapters/controllers/users/get-self-user.controller';
 import { IRequestEmailChangeController } from '@/src/interface-adapters/controllers/users/request-email-change.controller';
@@ -93,6 +95,7 @@ export const DI_SYMBOLS = {
   ICancelEmailChangeUseCase: Symbol.for('ICancelEmailChangeUseCase'),
   IGetPendingEmailChangeUseCase: Symbol.for('IGetPendingEmailChangeUseCase'),
   IUpdateUserPasswordUseCase: Symbol.for('IUpdateUserPasswordUseCase'),
+  IDeleteAccountUseCase: Symbol.for('IDeleteAccountUseCase'),
   IGetUserSettingsForUserUseCase: Symbol.for('IGetUserSettingsForUserUseCase'),
   IUpdateUserSettingsUseCase: Symbol.for('IUpdateUserSettingsUseCase'),
 
@@ -121,6 +124,7 @@ export const DI_SYMBOLS = {
     'IGetPendingEmailChangeController'
   ),
   IUpdateUserPasswordController: Symbol.for('IUpdateUserPasswordController'),
+  IDeleteAccountController: Symbol.for('IDeleteAccountController'),
   IGetUserSettingsForUserController: Symbol.for(
     'IGetUserSettingsForUserController'
   ),
@@ -164,6 +168,7 @@ export interface DI_RETURN_TYPES {
   ICancelEmailChangeUseCase: ICancelEmailChangeUseCase;
   IGetPendingEmailChangeUseCase: IGetPendingEmailChangeUseCase;
   IUpdateUserPasswordUseCase: IUpdateUserPasswordUseCase;
+  IDeleteAccountUseCase: IDeleteAccountUseCase;
   IGetUserSettingsForUserUseCase: IGetUserSettingsForUserUseCase;
   IUpdateUserSettingsUseCase: IUpdateUserSettingsUseCase;
 
@@ -186,6 +191,7 @@ export interface DI_RETURN_TYPES {
   ICancelEmailChangeController: ICancelEmailChangeController;
   IGetPendingEmailChangeController: IGetPendingEmailChangeController;
   IUpdateUserPasswordController: IUpdateUserPasswordController;
+  IDeleteAccountController: IDeleteAccountController;
   IGetUserSettingsForUserController: IGetUserSettingsForUserController;
   IUpdateUserSettingsController: IUpdateUserSettingsController;
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,5 +97,9 @@
   "emailChangeOtpInvalid": "Please enter a valid 6-digit code",
   "emailChangeOtpSuccess": "Email address updated successfully",
   "emailChangeOtpResent": "A new code has been sent",
-  "emailChangeOtpResend": "Resend code"
+  "emailChangeOtpResend": "Resend code",
+  "dangerZone": "Danger Zone",
+  "deleteAccount": "Delete Account",
+  "deleteAccountDescription": "Permanently delete your account, visa settings, and leave records. This action cannot be undone.",
+  "deleteAccountConfirmation": "This will permanently delete your account and all associated data. This action cannot be undone. Enter your password to confirm."
 }

--- a/messages/zh-Hant-HK.json
+++ b/messages/zh-Hant-HK.json
@@ -97,5 +97,9 @@
   "emailChangeOtpInvalid": "請輸入有效的6位數字驗證碼",
   "emailChangeOtpSuccess": "電郵地址更新成功",
   "emailChangeOtpResent": "新驗證碼已發送",
-  "emailChangeOtpResend": "重新發送驗證碼"
+  "emailChangeOtpResend": "重新發送驗證碼",
+  "dangerZone": "危險區域",
+  "deleteAccount": "刪除帳戶",
+  "deleteAccountDescription": "永久刪除您的帳戶、簽證設定及離開記錄，此操作無法復原。",
+  "deleteAccountConfirmation": "此操作將永久刪除您的帳戶及所有相關資料，且無法復原。請輸入密碼以確認。"
 }

--- a/src/application/repositories/email-change-tokens.repository.interface.ts
+++ b/src/application/repositories/email-change-tokens.repository.interface.ts
@@ -1,4 +1,5 @@
 import { EmailChangeToken } from '@/src/entities/models/email-change-token';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
 
 export interface IEmailChangeTokensRepository {
   createToken(
@@ -10,5 +11,5 @@ export interface IEmailChangeTokensRepository {
   getToken(tokenHash: string): Promise<EmailChangeToken | undefined>;
   getActiveTokenByUserId(userId: string): Promise<EmailChangeToken | undefined>;
   deleteToken(tokenHash: string): Promise<void>;
-  deleteTokensByUserId(userId: string): Promise<void>;
+  deleteTokensByUserId(userId: string, tx?: ITransaction): Promise<void>;
 }

--- a/src/application/repositories/leaves.repository.interface.ts
+++ b/src/application/repositories/leaves.repository.interface.ts
@@ -14,4 +14,5 @@ export interface ILeavesRepository {
     tx?: any
   ): Promise<Leave>;
   deleteLeave(id: number, tx?: any): Promise<void>;
+  deleteLeavesForUser(userId: string, tx?: any): Promise<void>;
 }

--- a/src/application/repositories/user-settings.repository.interface.ts
+++ b/src/application/repositories/user-settings.repository.interface.ts
@@ -11,4 +11,5 @@ export interface IUserSettingsRepository {
     input: Partial<UserSettingUpdate>,
     tx?: any
   ): Promise<UserSetting>;
+  deleteUserSettingsForUser(userId: string, tx?: any): Promise<void>;
 }

--- a/src/application/repositories/users.repository.interface.ts
+++ b/src/application/repositories/users.repository.interface.ts
@@ -13,4 +13,5 @@ export interface IUsersRepository {
   ): Promise<User>;
   verifyUserEmail(id: string): Promise<User>;
   applyEmailChange(userId: string, newEmail: string): Promise<User>;
+  deleteUser(id: string, tx?: ITransaction): Promise<void>;
 }

--- a/src/application/use-cases/users/delete-account.use-case.ts
+++ b/src/application/use-cases/users/delete-account.use-case.ts
@@ -1,0 +1,66 @@
+import { IEmailChangeTokensRepository } from '@/src/application/repositories/email-change-tokens.repository.interface';
+import { IEmailVerificationTokensRepository } from '@/src/application/repositories/email-verification-tokens.repository.interface';
+import { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
+import { IPasswordResetTokensRepository } from '@/src/application/repositories/password-reset-tokens.repository.interface';
+import { ISessionsRepository } from '@/src/application/repositories/sessions.repository.interface';
+import { IUserSettingsRepository } from '@/src/application/repositories/user-settings.repository.interface';
+import { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+import type { ITransaction } from '@/src/entities/models/transaction.interface';
+
+export type IDeleteAccountUseCase = ReturnType<typeof deleteAccountUseCase>;
+
+export const deleteAccountUseCase =
+  (
+    instrumentationService: IInstrumentationService,
+    authenticationService: IAuthenticationService,
+    usersRepository: IUsersRepository,
+    leavesRepository: ILeavesRepository,
+    userSettingsRepository: IUserSettingsRepository,
+    passwordResetTokensRepository: IPasswordResetTokensRepository,
+    emailVerificationTokensRepository: IEmailVerificationTokensRepository,
+    emailChangeTokensRepository: IEmailChangeTokensRepository,
+    sessionsRepository: ISessionsRepository
+  ) =>
+  (
+    input: {
+      currentPassword: string;
+      currentPasswordHash: string;
+    },
+    userId: string,
+    tx?: ITransaction
+  ): Promise<void> => {
+    return instrumentationService.startSpan(
+      { name: 'deleteAccount Use Case', op: 'function' },
+      async () => {
+        const matched = await authenticationService.validatePasswords(
+          input.currentPassword,
+          input.currentPasswordHash
+        );
+
+        if (!matched) {
+          throw new AuthenticationError('Current password is incorrect');
+        }
+
+        // GDPR/CCPA "right to erasure": remove every row referencing this
+        // user, then the user row itself, atomically within a single
+        // transaction. Deletes are explicit (rather than relying on
+        // `ON DELETE CASCADE`) since FK enforcement isn't guaranteed to be
+        // on for every connection/driver -- see drizzle/schema.ts.
+        await leavesRepository.deleteLeavesForUser(userId, tx);
+        await userSettingsRepository.deleteUserSettingsForUser(userId, tx);
+        await passwordResetTokensRepository.deleteTokensByUserId(userId, tx);
+        await emailVerificationTokensRepository.deleteTokensByUserId(
+          userId,
+          tx
+        );
+        await emailChangeTokensRepository.deleteTokensByUserId(userId, tx);
+        await sessionsRepository.deleteUserSession(userId, tx);
+        // The user row must be deleted last, after every table referencing
+        // it has been cleared.
+        await usersRepository.deleteUser(userId, tx);
+      }
+    );
+  };

--- a/src/infrastructure/repositories/email-change-tokens.repository.ts
+++ b/src/infrastructure/repositories/email-change-tokens.repository.ts
@@ -1,4 +1,4 @@
-import { db } from '@/drizzle';
+import { Transaction, db } from '@/drizzle';
 import { and, eq, gt } from 'drizzle-orm';
 
 import { emailChangeTokens } from '@/drizzle/schema';
@@ -120,12 +120,13 @@ export class EmailChangeTokensRepository implements IEmailChangeTokensRepository
     );
   }
 
-  async deleteTokensByUserId(userId: string): Promise<void> {
+  async deleteTokensByUserId(userId: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
     return await this.instrumentationService.startSpan(
       { name: 'EmailChangeTokensRepository > deleteTokensByUserId' },
       async () => {
         try {
-          const query = db
+          const query = invoker
             .delete(emailChangeTokens)
             .where(eq(emailChangeTokens.userId, userId));
           await this.instrumentationService.startSpan(

--- a/src/infrastructure/repositories/leaves.repository.ts
+++ b/src/infrastructure/repositories/leaves.repository.ts
@@ -159,4 +159,29 @@ export class LeavesRepository implements ILeavesRepository {
       }
     );
   }
+
+  async deleteLeavesForUser(userId: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
+
+    await this.instrumentationService.startSpan(
+      { name: 'LeavesRepository > deleteLeavesForUser' },
+      async () => {
+        try {
+          const query = invoker.delete(leaves).where(eq(leaves.userId, userId));
+
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // leave: convert to Entities error
+        }
+      }
+    );
+  }
 }

--- a/src/infrastructure/repositories/user-settings.repository.ts
+++ b/src/infrastructure/repositories/user-settings.repository.ts
@@ -117,4 +117,33 @@ export class UserSettingsRepository implements IUserSettingsRepository {
       }
     );
   }
+
+  async deleteUserSettingsForUser(
+    userId: string,
+    tx?: Transaction
+  ): Promise<void> {
+    const invoker = tx ?? db;
+    return await this.instrumentationService.startSpan(
+      { name: 'UserSettingsRepository > deleteUserSettingsForUser' },
+      async () => {
+        try {
+          const query = invoker
+            .delete(userSettings)
+            .where(eq(userSettings.userId, userId));
+
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err; // leave: convert to Entities error
+        }
+      }
+    );
+  }
 }

--- a/src/infrastructure/repositories/users.repository.ts
+++ b/src/infrastructure/repositories/users.repository.ts
@@ -261,4 +261,27 @@ export class UsersRepository implements IUsersRepository {
       }
     );
   }
+
+  async deleteUser(id: string, tx?: Transaction): Promise<void> {
+    const invoker = tx ?? db;
+    return await this.instrumentationService.startSpan(
+      { name: 'UsersRepository > deleteUser' },
+      async () => {
+        try {
+          const query = invoker.delete(users).where(eq(users.id, id));
+          await this.instrumentationService.startSpan(
+            {
+              name: query.toSQL().sql,
+              op: 'db.query',
+              attributes: { 'db.system': 'sqlite' },
+            },
+            () => query.execute()
+          );
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
+        }
+      }
+    );
+  }
 }

--- a/src/interface-adapters/controllers/users/delete-account.controller.ts
+++ b/src/interface-adapters/controllers/users/delete-account.controller.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import { SESSION_COOKIE } from '@/config';
+
+import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { ITransactionManagerService } from '@/src/application/services/transaction-manager.service.interface';
+import { IDeleteAccountUseCase } from '@/src/application/use-cases/users/delete-account.use-case';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+import { InputParseError } from '@/src/entities/errors/common';
+import { Cookie } from '@/src/entities/models/cookie';
+
+const inputSchema = z.object({
+  currentPassword: z.string().min(1),
+});
+
+export type IDeleteAccountController = ReturnType<
+  typeof deleteAccountController
+>;
+
+export const deleteAccountController =
+  (
+    instrumentationService: IInstrumentationService,
+    authenticationService: IAuthenticationService,
+    transactionManagerService: ITransactionManagerService,
+    deleteAccountUseCase: IDeleteAccountUseCase
+  ) =>
+  async (
+    input: Partial<z.infer<typeof inputSchema>>,
+    token: string | undefined
+  ): Promise<{ blankCookie: Cookie }> => {
+    return await instrumentationService.startSpan(
+      { name: 'deleteAccount Controller' },
+      async () => {
+        if (!token) {
+          throw new UnauthenticatedError(
+            'Must be logged in to delete your account'
+          );
+        }
+        const { user } = await authenticationService.validateSession(token);
+
+        const { data, error: inputParseError } = inputSchema.safeParse(input);
+        if (inputParseError) {
+          throw new InputParseError('Invalid data', { cause: inputParseError });
+        }
+
+        // Every write (leaves, settings, tokens, sessions, and finally the
+        // user row itself) happens atomically. No manual try/catch +
+        // tx.rollback() here: Drizzle already rolls back and rethrows the
+        // original error (e.g. AuthenticationError for a wrong password) on
+        // any failure, which we rely on for user-facing messaging.
+        await transactionManagerService.startTransaction((tx) =>
+          deleteAccountUseCase(
+            {
+              currentPassword: data.currentPassword,
+              currentPasswordHash: user.passwordHash,
+            },
+            user.id,
+            tx
+          )
+        );
+
+        const blankCookie: Cookie = {
+          name: SESSION_COOKIE,
+          value: '',
+          attributes: {},
+        };
+
+        return { blankCookie };
+      }
+    );
+  };

--- a/tests/units/application/use-cases/users/delete-account.use-case.test.ts
+++ b/tests/units/application/use-cases/users/delete-account.use-case.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { getInjection } from '@/di/container';
+import { AuthenticationError } from '@/src/entities/errors/auth';
+
+const signUpUseCase = getInjection('ISignUpUseCase');
+const createLeaveUseCase = getInjection('ICreateLeaveUseCase');
+const deleteAccountUseCase = getInjection('IDeleteAccountUseCase');
+const usersRepository = getInjection('IUsersRepository');
+const leavesRepository = getInjection('ILeavesRepository');
+const userSettingsRepository = getInjection('IUserSettingsRepository');
+const sessionsRepository = getInjection('ISessionRepository');
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('deletes the user and every row referencing them', async () => {
+  const { user, session } = await signUpUseCase({
+    email: 'delete-account-success@test.com',
+    password: 'delete-account-password',
+    locale: 'en',
+  });
+
+  await createLeaveUseCase(
+    {
+      startDate: new Date(2025, 5, 1),
+      endDate: new Date(2025, 5, 5),
+    },
+    user.id
+  );
+
+  await deleteAccountUseCase(
+    {
+      currentPassword: 'delete-account-password',
+      currentPasswordHash: user.passwordHash,
+    },
+    user.id
+  );
+
+  await expect(usersRepository.getUser(user.id)).resolves.toBeUndefined();
+  await expect(leavesRepository.getLeavesForUser(user.id)).resolves.toEqual(
+    []
+  );
+  await expect(
+    userSettingsRepository.getUserSettingsForUser(user.id)
+  ).resolves.toBeUndefined();
+  await expect(
+    sessionsRepository.getSession(session.id)
+  ).resolves.toBeUndefined();
+});
+
+it('throws for the wrong current password and deletes nothing', async () => {
+  const { user } = await signUpUseCase({
+    email: 'delete-account-wrong-password@test.com',
+    password: 'delete-account-password',
+    locale: 'en',
+  });
+
+  await expect(
+    deleteAccountUseCase(
+      {
+        currentPassword: 'not-the-password',
+        currentPasswordHash: user.passwordHash,
+      },
+      user.id
+    )
+  ).rejects.toBeInstanceOf(AuthenticationError);
+
+  await expect(usersRepository.getUser(user.id)).resolves.toBeDefined();
+});

--- a/tests/units/components/delete-account-form.test.tsx
+++ b/tests/units/components/delete-account-form.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { expect, it, vi } from 'vitest';
+
+import { DeleteAccountForm } from '@/app/_components/delete-account-form';
+import { userActions } from '@/app/actions';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  userActions: { deleteAccount: vi.fn() },
+}));
+
+it('renders the trigger button', () => {
+  render(<DeleteAccountForm />);
+
+  expect(
+    screen.getByRole('button', { name: 'deleteAccount' })
+  ).toBeInTheDocument();
+});
+
+it('opens a confirmation dialog requiring the current password on click', async () => {
+  render(<DeleteAccountForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'deleteAccount' }));
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+  expect(screen.getByText('deleteAccountConfirmation')).toBeInTheDocument();
+  expect(screen.getByLabelText('currentPassword')).toBeInTheDocument();
+});
+
+it('shows pleaseInput when submitted without a password', async () => {
+  render(<DeleteAccountForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'deleteAccount' }));
+  await userEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+  expect(await screen.findByText('pleaseInput')).toBeInTheDocument();
+  expect(userActions.deleteAccount).not.toHaveBeenCalled();
+});
+
+it('calls userActions.deleteAccount with the password on confirm', async () => {
+  // A successful call redirects server-side and never resolves with a
+  // value the client sees; the mock is left unconfigured (resolves
+  // `undefined` by default) to match that, since only the invocation
+  // itself is under test here.
+  render(<DeleteAccountForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'deleteAccount' }));
+  await userEvent.type(screen.getByLabelText('currentPassword'), 'my-password');
+  await userEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+  await waitFor(() => {
+    expect(userActions.deleteAccount).toHaveBeenCalledTimes(1);
+  });
+  const formData = vi.mocked(userActions.deleteAccount).mock.calls[0][0];
+  expect(formData.get('currentPassword')).toBe('my-password');
+});
+
+it('shows an error toast when the action returns an error', async () => {
+  vi.mocked(userActions.deleteAccount).mockResolvedValue({
+    error: 'Current password is incorrect',
+  });
+  render(<DeleteAccountForm />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'deleteAccount' }));
+  await userEvent.type(screen.getByLabelText('currentPassword'), 'wrong');
+  await userEvent.click(screen.getByRole('button', { name: 'confirm' }));
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('Current password is incorrect');
+  });
+});

--- a/tests/units/interface-adapters/controllers/users/delete-account.controller.test.ts
+++ b/tests/units/interface-adapters/controllers/users/delete-account.controller.test.ts
@@ -1,0 +1,86 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { SESSION_COOKIE } from '@/config';
+
+import { getInjection } from '@/di/container';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+
+const signUpUseCase = getInjection('ISignUpUseCase');
+const deleteAccountController = getInjection('IDeleteAccountController');
+const usersRepository = getInjection('IUsersRepository');
+const sessionsRepository = getInjection('ISessionRepository');
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('deletes the account and returns a blank session cookie', async () => {
+  const { user, cookie } = await signUpUseCase({
+    email: 'delete-account-controller-success@test.com',
+    password: 'delete-account-password',
+    locale: 'en',
+  });
+
+  const { blankCookie } = await deleteAccountController(
+    { currentPassword: 'delete-account-password' },
+    cookie.value
+  );
+
+  expect(blankCookie).toMatchObject({ name: SESSION_COOKIE, value: '' });
+  await expect(usersRepository.getUser(user.id)).resolves.toBeUndefined();
+});
+
+it('throws for the wrong current password and deletes nothing', async () => {
+  const { user, cookie } = await signUpUseCase({
+    email: 'delete-account-controller-wrong-password@test.com',
+    password: 'delete-account-password',
+    locale: 'en',
+  });
+
+  await expect(
+    deleteAccountController(
+      { currentPassword: 'not-the-password' },
+      cookie.value
+    )
+  ).rejects.toThrow('Current password is incorrect');
+
+  await expect(usersRepository.getUser(user.id)).resolves.toBeDefined();
+});
+
+it('throws for unauthenticated', async () => {
+  await expect(
+    deleteAccountController({ currentPassword: 'whatever' }, undefined)
+  ).rejects.toBeInstanceOf(UnauthenticatedError);
+});
+
+it('rolls back the whole deletion if a later step fails, leaving nothing committed', async () => {
+  const { user, cookie } = await signUpUseCase({
+    email: 'delete-account-controller-rollback@test.com',
+    password: 'delete-account-password',
+    locale: 'en',
+  });
+
+  // Force the last write in the transaction (deleting the user row itself)
+  // to fail, simulating a transient infra error after every other write
+  // has already been queued but before the transaction commits.
+  vi.spyOn(usersRepository, 'deleteUser').mockImplementationOnce(async () => {
+    throw new Error('simulated failure');
+  });
+
+  await expect(
+    deleteAccountController(
+      { currentPassword: 'delete-account-password' },
+      cookie.value
+    )
+  ).rejects.toThrow('simulated failure');
+
+  // Nothing from the failed attempt should have been committed.
+  await expect(usersRepository.getUser(user.id)).resolves.toBeDefined();
+  await expect(sessionsRepository.getUserSession(user.id)).resolves.toBeTruthy();
+});


### PR DESCRIPTION
## Summary
First of three follow-ups from the compliance discussion. Adds a self-service "delete my account" flow — the biggest concrete gap identified: there was no way for a user to exercise their **right to erasure** (GDPR Art. 17 / CCPA).

- New `deleteAccountUseCase`, requiring current-password confirmation before proceeding (same safety pattern as `updateUserPasswordUseCase`), so an irreversible action can't be triggered by e.g. a hijacked session alone.
- Deletes every row referencing the user — leaves, user settings, password-reset tokens, email-verification tokens, email-change tokens, and sessions — then the user row itself, **all atomically in one transaction** (reusing the `tx`-aware repository methods and controller pattern from #39). Deletes are explicit rather than relying on `ON DELETE CASCADE`, since only 1 of the 5 foreign keys referencing `users` in `drizzle/schema.ts` even declares cascade behavior, and FK enforcement itself isn't guaranteed to be on for every connection/driver.
- Controller returns a blank session cookie so the server action can clear the browser's cookie once the underlying session row is gone.
- New **"Danger Zone"** section on the settings page — a destructive button opens a confirmation dialog requiring the current password before submitting (mirrors the existing leave-delete confirmation UX). Added strings for both locales (en, zh-Hant-HK).

### Repository changes needed to support this
- `IUsersRepository.deleteUser` (new)
- `ILeavesRepository.deleteLeavesForUser` / `IUserSettingsRepository.deleteUserSettingsForUser` (new bulk-by-user deletes — only single-record deletes existed before)
- `IEmailChangeTokensRepository.deleteTokensByUserId` now accepts `tx` (the one write method in that repository still missing it)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 145/145 passing (11 new: use-case, controller, and component tests)
- [x] Use-case test verifies full cleanup (user, leaves, settings, session all gone) and that a wrong password deletes nothing
- [x] Controller tests cover success, wrong password, unauthenticated, and — mirroring the reset-password rollback test from #39 — a forced mid-transaction failure proving the deletion is genuinely atomic, not just wired to look that way
- [x] Component tests cover the confirmation dialog, empty-password validation, and form submission
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an account deletion flow in settings, including a confirmation dialog and a danger zone section.
  * Users can now delete their account after confirming with their current password.
  * Added translated text for the new deletion prompts in English and Traditional Chinese.

* **Bug Fixes**
  * Account deletion now clears the active session and returns users to the sign-in screen.
  * Related user data is removed consistently during deletion to avoid leftover personal records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->