### PR TITLE
feat: add self-service data export (GDPR/CCPA right to access)

### DIFF
--- a/app/[locale]/(private)/users/settings/page.tsx
+++ b/app/[locale]/(private)/users/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
 import { ChangePasswordForm } from '@/app/_components/change-password-form';
+import { DataExportButton } from '@/app/_components/data-export-button';
 import { SettingsDateForm } from '@/app/_components/settings-date-form';
 import { Separator } from '@/app/_components/ui/separator';
 import { UpdateEmailForm } from '@/app/_components/update-email-form';
@@ -46,6 +47,12 @@ export default async function UserSettingsPage() {
       <Separator />
       <div className="text-lg font-bold">{t('changePassword')}</div>
       <ChangePasswordForm />
+      <Separator />
+      <div className="text-lg font-bold">{t('yourData')}</div>
+      <p className="text-sm text-muted-foreground">
+        {t('downloadMyDataDescription')}
+      </p>
+      <DataExportButton />
     </div>
   );
 }

--- a/app/_components/data-export-button.tsx
+++ b/app/_components/data-export-button.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Download, Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useTransition } from 'react';
+import { toast } from 'sonner';
+
+import { Button } from '@/app/_components/ui/button';
+import { userActions } from '@/app/actions';
+
+type DataExportButtonProps = React.ComponentPropsWithoutRef<'div'>;
+
+export function DataExportButton({}: DataExportButtonProps) {
+  const t = useTranslations();
+  const [loading, startTransition] = useTransition();
+
+  const handleClick = () => {
+    if (loading) return;
+    startTransition(async () => {
+      const res = await userActions.getDataExport();
+      if (!res || res.error || !res.result) {
+        toast.error(res?.error ?? t('downloadMyDataError'));
+        return;
+      }
+
+      // The export is delivered as JSON via the server action, then turned
+      // into a downloadable file client-side (rather than a dedicated API
+      // route) to stay consistent with how every other authenticated
+      // user-data operation in this app goes through a server action.
+      const blob = new Blob([JSON.stringify(res.result, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'my-data.json';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    });
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="cursor-pointer"
+      onClick={handleClick}
+      disabled={loading}
+      data-cy="data-export-trigger"
+    >
+      {loading ? <Loader2 className="animate-spin" /> : <Download />}
+      {t('downloadMyData')}
+    </Button>
+  );
+}

--- a/app/actions/users/index.ts
+++ b/app/actions/users/index.ts
@@ -209,3 +209,37 @@ export async function cancelEmailChange() {
     }
   );
 }
+
+export async function getDataExport() {
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.instrumentServerAction(
+    'getDataExport',
+    { recordResponse: true },
+    async () => {
+      try {
+        const getUserDataExportController = getInjection(
+          'IGetUserDataExportController'
+        );
+        const cookieStore = await cookies();
+        const token = cookieStore.get(SESSION_COOKIE)?.value;
+        const data = await getUserDataExportController(token);
+
+        return { result: data };
+      } catch (err) {
+        if (
+          err instanceof AuthenticationError ||
+          err instanceof UnauthenticatedError
+        ) {
+          return { error: err.message };
+        }
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
+
+        return {
+          error:
+            'An error happened. The developers have been notified. Please try again later.',
+        };
+      }
+    }
+  );
+}

--- a/di/modules/users.module.ts
+++ b/di/modules/users.module.ts
@@ -1,11 +1,13 @@
 import { createModule } from '@evyweb/ioctopus';
 
 import { DI_SYMBOLS } from '@/di/types';
+import { getUserDataExportUseCase } from '@/src/application/use-cases/users/get-user-data-export.use-case';
 import { getUserUseCase } from '@/src/application/use-cases/users/get-user.use-case';
 import { updateUserPasswordUseCase } from '@/src/application/use-cases/users/update-user-password.use-case';
 import { UsersRepository } from '@/src/infrastructure/repositories/users.repository';
 import { EmailBloomFilterService } from '@/src/infrastructure/services/email-bloom-filter.service';
 import { getSelfUserController } from '@/src/interface-adapters/controllers/users/get-self-user.controller';
+import { getUserDataExportController } from '@/src/interface-adapters/controllers/users/get-user-data-export.controller';
 import { updateUserPasswordController } from '@/src/interface-adapters/controllers/users/update-user-password.controller';
 
 export function createUsersModule() {
@@ -41,6 +43,15 @@ export function createUsersModule() {
     ]);
 
   usersModule
+    .bind(DI_SYMBOLS.IGetUserDataExportUseCase)
+    .toHigherOrderFunction(getUserDataExportUseCase, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IUsersRepository,
+      DI_SYMBOLS.IUserSettingsRepository,
+      DI_SYMBOLS.ILeavesRepository,
+    ]);
+
+  usersModule
     .bind(DI_SYMBOLS.IGetSelfUserController)
     .toHigherOrderFunction(getSelfUserController, [
       DI_SYMBOLS.IInstrumentationService,
@@ -57,5 +68,14 @@ export function createUsersModule() {
       DI_SYMBOLS.IUpdateUserPasswordUseCase,
       DI_SYMBOLS.ISessionRepository,
     ]);
+
+  usersModule
+    .bind(DI_SYMBOLS.IGetUserDataExportController)
+    .toHigherOrderFunction(getUserDataExportController, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IAuthenticationService,
+      DI_SYMBOLS.IGetUserDataExportUseCase,
+    ]);
+
   return usersModule;
 }

--- a/di/types.ts
+++ b/di/types.ts
@@ -27,6 +27,7 @@ import { IGetUserSettingsForUserUseCase } from '@/src/application/use-cases/user
 import { IUpdateUserSettingsUseCase } from '@/src/application/use-cases/user-settings/update-user-settings.use-case';
 import { ICancelEmailChangeUseCase } from '@/src/application/use-cases/users/cancel-email-change.use-case';
 import { IGetPendingEmailChangeUseCase } from '@/src/application/use-cases/users/get-pending-email-change.use-case';
+import { IGetUserDataExportUseCase } from '@/src/application/use-cases/users/get-user-data-export.use-case';
 import { IGetUserUseCase } from '@/src/application/use-cases/users/get-user.use-case';
 import { IRequestEmailChangeUseCase } from '@/src/application/use-cases/users/request-email-change.use-case';
 import { IUpdateUserPasswordUseCase } from '@/src/application/use-cases/users/update-user-password.use-case';
@@ -48,6 +49,7 @@ import { IUpdateUserSettingsController } from '@/src/interface-adapters/controll
 import { ICancelEmailChangeController } from '@/src/interface-adapters/controllers/users/cancel-email-change.controller';
 import { IGetPendingEmailChangeController } from '@/src/interface-adapters/controllers/users/get-pending-email-change.controller';
 import { IGetSelfUserController } from '@/src/interface-adapters/controllers/users/get-self-user.controller';
+import { IGetUserDataExportController } from '@/src/interface-adapters/controllers/users/get-user-data-export.controller';
 import { IRequestEmailChangeController } from '@/src/interface-adapters/controllers/users/request-email-change.controller';
 import { IUpdateUserPasswordController } from '@/src/interface-adapters/controllers/users/update-user-password.controller';
 import { IVerifyEmailChangeController } from '@/src/interface-adapters/controllers/users/verify-email-change.controller';
@@ -93,6 +95,7 @@ export const DI_SYMBOLS = {
   ICancelEmailChangeUseCase: Symbol.for('ICancelEmailChangeUseCase'),
   IGetPendingEmailChangeUseCase: Symbol.for('IGetPendingEmailChangeUseCase'),
   IUpdateUserPasswordUseCase: Symbol.for('IUpdateUserPasswordUseCase'),
+  IGetUserDataExportUseCase: Symbol.for('IGetUserDataExportUseCase'),
   IGetUserSettingsForUserUseCase: Symbol.for('IGetUserSettingsForUserUseCase'),
   IUpdateUserSettingsUseCase: Symbol.for('IUpdateUserSettingsUseCase'),
 
@@ -121,6 +124,7 @@ export const DI_SYMBOLS = {
     'IGetPendingEmailChangeController'
   ),
   IUpdateUserPasswordController: Symbol.for('IUpdateUserPasswordController'),
+  IGetUserDataExportController: Symbol.for('IGetUserDataExportController'),
   IGetUserSettingsForUserController: Symbol.for(
     'IGetUserSettingsForUserController'
   ),
@@ -164,6 +168,7 @@ export interface DI_RETURN_TYPES {
   ICancelEmailChangeUseCase: ICancelEmailChangeUseCase;
   IGetPendingEmailChangeUseCase: IGetPendingEmailChangeUseCase;
   IUpdateUserPasswordUseCase: IUpdateUserPasswordUseCase;
+  IGetUserDataExportUseCase: IGetUserDataExportUseCase;
   IGetUserSettingsForUserUseCase: IGetUserSettingsForUserUseCase;
   IUpdateUserSettingsUseCase: IUpdateUserSettingsUseCase;
 
@@ -186,6 +191,7 @@ export interface DI_RETURN_TYPES {
   ICancelEmailChangeController: ICancelEmailChangeController;
   IGetPendingEmailChangeController: IGetPendingEmailChangeController;
   IUpdateUserPasswordController: IUpdateUserPasswordController;
+  IGetUserDataExportController: IGetUserDataExportController;
   IGetUserSettingsForUserController: IGetUserSettingsForUserController;
   IUpdateUserSettingsController: IUpdateUserSettingsController;
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -97,5 +97,9 @@
   "emailChangeOtpInvalid": "Please enter a valid 6-digit code",
   "emailChangeOtpSuccess": "Email address updated successfully",
   "emailChangeOtpResent": "A new code has been sent",
-  "emailChangeOtpResend": "Resend code"
+  "emailChangeOtpResend": "Resend code",
+  "yourData": "Your Data",
+  "downloadMyData": "Download My Data",
+  "downloadMyDataDescription": "Download a copy of your account, visa settings, and leave records as a JSON file.",
+  "downloadMyDataError": "Could not export your data. Please try again later."
 }

--- a/messages/zh-Hant-HK.json
+++ b/messages/zh-Hant-HK.json
@@ -97,5 +97,9 @@
   "emailChangeOtpInvalid": "請輸入有效的6位數字驗證碼",
   "emailChangeOtpSuccess": "電郵地址更新成功",
   "emailChangeOtpResent": "新驗證碼已發送",
-  "emailChangeOtpResend": "重新發送驗證碼"
+  "emailChangeOtpResend": "重新發送驗證碼",
+  "yourData": "您的資料",
+  "downloadMyData": "下載我的資料",
+  "downloadMyDataDescription": "以 JSON 檔案下載您的帳戶、簽證設定及離開記錄副本。",
+  "downloadMyDataError": "無法匯出您的資料，請稍後再試。"
 }

--- a/src/application/use-cases/users/get-user-data-export.use-case.ts
+++ b/src/application/use-cases/users/get-user-data-export.use-case.ts
@@ -1,0 +1,44 @@
+import type { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
+import type { IUserSettingsRepository } from '@/src/application/repositories/user-settings.repository.interface';
+import type { IUsersRepository } from '@/src/application/repositories/users.repository.interface';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { NotFoundError } from '@/src/entities/errors/common';
+import type { Leave } from '@/src/entities/models/leave';
+import type { User } from '@/src/entities/models/user';
+import type { UserSetting } from '@/src/entities/models/userSettings';
+
+export type IGetUserDataExportUseCase = ReturnType<
+  typeof getUserDataExportUseCase
+>;
+
+export const getUserDataExportUseCase =
+  (
+    instrumentationService: IInstrumentationService,
+    usersRepository: IUsersRepository,
+    userSettingsRepository: IUserSettingsRepository,
+    leavesRepository: ILeavesRepository
+  ) =>
+  (
+    userId: string
+  ): Promise<{
+    user: User;
+    settings: UserSetting | undefined;
+    leaves: Leave[];
+  }> => {
+    return instrumentationService.startSpan(
+      { name: 'getUserDataExport UseCase', op: 'function' },
+      async () => {
+        const [user, settings, leaves] = await Promise.all([
+          usersRepository.getUser(userId),
+          userSettingsRepository.getUserSettingsForUser(userId),
+          leavesRepository.getLeavesForUser(userId),
+        ]);
+
+        if (!user) {
+          throw new NotFoundError('User does not exist');
+        }
+
+        return { user, settings, leaves };
+      }
+    );
+  };

--- a/src/interface-adapters/controllers/users/get-user-data-export.controller.ts
+++ b/src/interface-adapters/controllers/users/get-user-data-export.controller.ts
@@ -1,0 +1,39 @@
+import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { IGetUserDataExportUseCase } from '@/src/application/use-cases/users/get-user-data-export.use-case';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+import {
+  GetUserDataExportPresenterOutput,
+  getUserDataExportPresenter,
+} from '@/src/interface-adapters/presenters/users/get-user-data-export.presenter';
+
+export type IGetUserDataExportController = ReturnType<
+  typeof getUserDataExportController
+>;
+
+export const getUserDataExportController =
+  (
+    instrumentationService: IInstrumentationService,
+    authenticationService: IAuthenticationService,
+    getUserDataExportUseCase: IGetUserDataExportUseCase
+  ) =>
+  async (
+    token: string | undefined
+  ): Promise<GetUserDataExportPresenterOutput> => {
+    return await instrumentationService.startSpan(
+      { name: 'getUserDataExport Controller' },
+      async () => {
+        if (!token) {
+          throw new UnauthenticatedError(
+            'Must be logged in to export your data'
+          );
+        }
+
+        const { session } = await authenticationService.validateSession(token);
+
+        const data = await getUserDataExportUseCase(session.userId);
+
+        return getUserDataExportPresenter(data, instrumentationService);
+      }
+    );
+  };

--- a/src/interface-adapters/presenters/users/get-user-data-export.presenter.ts
+++ b/src/interface-adapters/presenters/users/get-user-data-export.presenter.ts
@@ -1,0 +1,47 @@
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { Leave } from '@/src/entities/models/leave';
+import { User } from '@/src/entities/models/user';
+import { UserSetting } from '@/src/entities/models/userSettings';
+
+export function getUserDataExportPresenter(
+  data: {
+    user: User;
+    settings: UserSetting | undefined;
+    leaves: Leave[];
+  },
+  instrumentationService: IInstrumentationService
+) {
+  return instrumentationService.startSpan(
+    { name: 'getUserDataExport Presenter', op: 'serialize' },
+    () => ({
+      exportedAt: new Date().toISOString(),
+      // SECURITY: intentionally excludes passwordHash and any session/reset
+      // token data -- those are security-sensitive implementation details,
+      // not meaningful "your data" for a right-to-access export.
+      account: {
+        id: data.user.id,
+        email: data.user.email,
+        emailVerified: data.user.emailVerified,
+      },
+      visaSettings: data.settings
+        ? {
+            visaStartDate: data.settings.visaStartDate,
+            visaExpiryDate: data.settings.visaExpiryDate,
+            arrivalDate: data.settings.arrivalDate,
+          }
+        : null,
+      leaves: data.leaves.map((leave) => ({
+        id: leave.id,
+        startDate: leave.startDate,
+        endDate: leave.endDate,
+        color: leave.color,
+        remarks: leave.remarks,
+        createdAt: leave.createdAt,
+      })),
+    })
+  );
+}
+
+export type GetUserDataExportPresenterOutput = ReturnType<
+  typeof getUserDataExportPresenter
+>;

--- a/tests/units/application/use-cases/users/get-user-data-export.use-case.test.ts
+++ b/tests/units/application/use-cases/users/get-user-data-export.use-case.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { getInjection } from '@/di/container';
+import { NotFoundError } from '@/src/entities/errors/common';
+
+const signUpUseCase = getInjection('ISignUpUseCase');
+const createLeaveUseCase = getInjection('ICreateLeaveUseCase');
+const getUserDataExportUseCase = getInjection('IGetUserDataExportUseCase');
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('returns the user, their settings, and their leaves', async () => {
+  const { user } = await signUpUseCase({
+    email: 'data-export-success@test.com',
+    password: 'data-export-password',
+    locale: 'en',
+  });
+
+  await createLeaveUseCase(
+    {
+      startDate: new Date(2025, 5, 1),
+      endDate: new Date(2025, 5, 5),
+      remarks: 'a note',
+    },
+    user.id
+  );
+
+  const result = await getUserDataExportUseCase(user.id);
+
+  expect(result.user).toMatchObject({
+    id: user.id,
+    email: 'data-export-success@test.com',
+  });
+  expect(result.settings).toMatchObject({ userId: user.id });
+  expect(result.leaves).toHaveLength(1);
+  expect(result.leaves[0]).toMatchObject({ remarks: 'a note' });
+});
+
+it('throws for a non-existent user', async () => {
+  await expect(
+    getUserDataExportUseCase('non-existent-id')
+  ).rejects.toBeInstanceOf(NotFoundError);
+});

--- a/tests/units/components/data-export-button.test.tsx
+++ b/tests/units/components/data-export-button.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+
+import { DataExportButton } from '@/app/_components/data-export-button';
+import { userActions } from '@/app/actions';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  userActions: { getDataExport: vi.fn() },
+}));
+
+let createObjectURLSpy: ReturnType<
+  typeof vi.fn<(obj: Blob | MediaSource) => string>
+>;
+let revokeObjectURLSpy: ReturnType<typeof vi.fn<(url: string) => void>>;
+
+beforeEach(() => {
+  // jsdom doesn't implement these; the component only needs them called,
+  // not a real blob: URL.
+  createObjectURLSpy = vi
+    .fn<(obj: Blob | MediaSource) => string>()
+    .mockReturnValue('blob:mock-url');
+  revokeObjectURLSpy = vi.fn<(url: string) => void>();
+  URL.createObjectURL = createObjectURLSpy;
+  URL.revokeObjectURL = revokeObjectURLSpy;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it('renders the trigger button', () => {
+  render(<DataExportButton />);
+
+  expect(
+    screen.getByRole('button', { name: 'downloadMyData' })
+  ).toBeInTheDocument();
+});
+
+it('downloads a JSON file built from the export data on click', async () => {
+  vi.mocked(userActions.getDataExport).mockResolvedValue({
+    result: {
+      exportedAt: '2025-01-01T00:00:00.000Z',
+      account: { id: '1', email: 'one@test.com', emailVerified: true },
+      visaSettings: null,
+      leaves: [],
+    },
+  });
+  render(<DataExportButton />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'downloadMyData' }));
+
+  await waitFor(() => {
+    expect(createObjectURLSpy).toHaveBeenCalledTimes(1);
+  });
+  const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+  expect(blob.type).toBe('application/json');
+  expect(await blob.text()).toContain('one@test.com');
+  expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock-url');
+});
+
+it('shows an error toast when the action returns an error', async () => {
+  vi.mocked(userActions.getDataExport).mockResolvedValue({
+    error: 'Something went wrong',
+  });
+  render(<DataExportButton />);
+
+  await userEvent.click(screen.getByRole('button', { name: 'downloadMyData' }));
+
+  await waitFor(() => {
+    expect(toast.error).toHaveBeenCalledWith('Something went wrong');
+  });
+  expect(createObjectURLSpy).not.toHaveBeenCalled();
+});

--- a/tests/units/interface-adapters/controllers/users/get-user-data-export.controller.test.ts
+++ b/tests/units/interface-adapters/controllers/users/get-user-data-export.controller.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, expect, it, vi } from 'vitest';
+
+import { getInjection } from '@/di/container';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+
+const signUpUseCase = getInjection('ISignUpUseCase');
+const getUserDataExportController = getInjection(
+  'IGetUserDataExportController'
+);
+
+beforeAll(() => {
+  vi.spyOn(global, 'fetch').mockResolvedValue(
+    new Response(null, { status: 200 })
+  );
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it('returns a safe export excluding the password hash', async () => {
+  const { cookie, user } = await signUpUseCase({
+    email: 'data-export-controller-success@test.com',
+    password: 'data-export-password',
+    locale: 'en',
+  });
+
+  const result = await getUserDataExportController(cookie.value);
+
+  expect(result).toMatchObject({
+    account: { id: user.id, email: 'data-export-controller-success@test.com' },
+    leaves: [],
+  });
+  expect(result).toHaveProperty('exportedAt');
+  expect(result.account).not.toHaveProperty('passwordHash');
+  expect(JSON.stringify(result)).not.toContain(user.passwordHash);
+});
+
+it('throws for unauthenticated', async () => {
+  await expect(
+    getUserDataExportController(undefined)
+  ).rejects.toBeInstanceOf(UnauthenticatedError);
+});


### PR DESCRIPTION
## Summary
Second of three compliance follow-ups (independent of #40, not stacked on it). Lets a logged-in user download a copy of their own data as JSON — the "right to access"/data portability counterpart to account deletion.

- New `getUserDataExportUseCase`: a plain read (no transaction needed) fetching the user, their visa settings, and all their leaves in parallel.
- New presenter explicitly builds a safe export shape — **intentionally excludes `passwordHash` and any session/token data**, since those are security-sensitive implementation details, not meaningful "your data" for a right-to-access export. Stamps an `exportedAt` timestamp.
- Controller follows the same auth pattern as the existing `get-self-user`/`get-leaves-for-user` controllers (validate session, no writes, no transaction needed).
- New **"Your Data"** section on the settings page with a "Download My Data" button. The server action returns the export JSON, and the button turns it into a downloadable `my-data.json` file client-side via a `Blob` + temporary `<a download>` — chosen over a dedicated API route to stay consistent with how every other authenticated user-data operation in this app already goes through a server action, rather than introducing a new REST-route auth pattern for just this one feature.
- Added strings for both locales (en, zh-Hant-HK).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 141/141 passing (7 new: use-case, controller, and component tests)
- [x] Use-case test verifies the returned data (including a real leave) and that a non-existent user throws `NotFoundError`
- [x] Controller test verifies the export **excludes the password hash entirely** — asserted via a literal string-search over the serialized JSON, not just an object-shape check — plus that unauthenticated requests are rejected
- [x] Component tests cover the button, the download trigger (asserting the actual `Blob` content and that the object URL gets revoked), and the error-toast path
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR