### PR TITLE
chore: make Sentry PII handling explicit (sendDefaultPii, replay masking)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -6,8 +6,23 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
+  // COMPLIANCE/PRIVACY: explicit opt-out of Sentry's "send default PII"
+  // behavior (IP addresses, request headers/cookies, etc.). Keep this
+  // false unless there's a documented reason to collect it -- see the
+  // Privacy Policy's data-inventory section.
+  sendDefaultPii: false,
+
   // Add optional integrations for additional features
-  integrations: [Sentry.replayIntegration()],
+  integrations: [
+    Sentry.replayIntegration({
+      // COMPLIANCE/PRIVACY: session replay records real user screens.
+      // These are Sentry's privacy-safe defaults, made explicit here so
+      // the choice is self-documenting and can't silently regress if the
+      // SDK's defaults ever change.
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -7,6 +7,12 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
+  // COMPLIANCE/PRIVACY: explicit opt-out of Sentry's "send default PII"
+  // behavior (IP addresses, request headers/cookies, etc.). Keep this
+  // false unless there's a documented reason to collect it -- see the
+  // Privacy Policy's data-inventory section.
+  sendDefaultPii: false,
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -6,6 +6,12 @@ import * as Sentry from '@sentry/nextjs';
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
 
+  // COMPLIANCE/PRIVACY: explicit opt-out of Sentry's "send default PII"
+  // behavior (IP addresses, request headers/cookies, etc.). Keep this
+  // false unless there's a documented reason to collect it -- see the
+  // Privacy Policy's data-inventory section.
+  sendDefaultPii: false,
+
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,
 


### PR DESCRIPTION
## Summary
Third of three compliance follow-ups (independent of #40/#41). No behavior change intended — this makes two privacy-relevant Sentry choices explicit in code instead of relying on SDK defaults, so they're self-documenting, reviewable, and can't silently regress if the SDK's defaults ever change:

- `sendDefaultPii: false` added to all three Sentry init calls (client, server, edge). This is already the SDK default, but was implicit; the Privacy Policy work assumed this was the case and it's now an explicit, auditable choice rather than an assumption.
- `Sentry.replayIntegration({ maskAllText: true, blockAllMedia: true })` in the client config. Session replay records real user screens/interactions; these are also the SDK's privacy-safe defaults, made explicit for the same reason.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 134/134 passing (unaffected baseline; no test coverage exists or is meaningful for these Next.js instrumentation hook files, confirmed no existing test references them)
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR