### PR TITLE
chore: add privacy notice under the leave remarks field

### DIFF
--- a/app/_components/leave-form.tsx
+++ b/app/_components/leave-form.tsx
@@ -167,6 +167,7 @@ export function LeaveForm({ leave }: LeaveFormProps) {
                   {...field}
                 />
               </FormControl>
+              <FormDescription>{t('remarksPrivacyNotice')}</FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,5 +105,6 @@
   "dangerZone": "Danger Zone",
   "deleteAccount": "Delete Account",
   "deleteAccountDescription": "Permanently delete your account, visa settings, and leave records. This action cannot be undone.",
-  "deleteAccountConfirmation": "This will permanently delete your account and all associated data. This action cannot be undone. Enter your password to confirm."
+  "deleteAccountConfirmation": "This will permanently delete your account and all associated data. This action cannot be undone. Enter your password to confirm.",
+  "remarksPrivacyNotice": "Avoid including sensitive personal details (e.g. health or family information)."
 }

--- a/messages/zh-Hant-HK.json
+++ b/messages/zh-Hant-HK.json
@@ -105,5 +105,6 @@
   "dangerZone": "危險區域",
   "deleteAccount": "刪除帳戶",
   "deleteAccountDescription": "永久刪除您的帳戶、簽證設定及離開記錄，此操作無法復原。",
-  "deleteAccountConfirmation": "此操作將永久刪除您的帳戶及所有相關資料，且無法復原。請輸入密碼以確認。"
+  "deleteAccountConfirmation": "此操作將永久刪除您的帳戶及所有相關資料，且無法復原。請輸入密碼以確認。",
+  "remarksPrivacyNotice": "請避免填寫敏感個人資料（例如健康或家庭狀況）。"
 }

--- a/tests/units/components/leave-form.test.tsx
+++ b/tests/units/components/leave-form.test.tsx
@@ -97,6 +97,7 @@ it('renders the date, color, remarks fields and a submit button', () => {
   expect(screen.getByLabelText('endDate')).toBeInTheDocument();
   expect(screen.getByLabelText('color')).toBeInTheDocument();
   expect(screen.getByLabelText('remarks')).toBeInTheDocument();
+  expect(screen.getByText('remarksPrivacyNotice')).toBeInTheDocument();
   expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
 });
 


### PR DESCRIPTION
## Summary
Small data-minimization item from the compliance follow-ups. The leave `remarks` field is free text, and a user could type sensitive personal details into it (health, family circumstances, etc.) with no particular reason for the app to hold or protect that specially. Adds a short hint below the field asking users to avoid that — no added friction, just a nudge.

- New `FormDescription` under the remarks field in `leave-form.tsx`, using the same pattern already used for the date fields' hint text.
- Added the string for both locales (en, zh-Hant-HK).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 152/152 passing
- [x] Added an assertion that the notice renders alongside the remarks field
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR