### PR TITLE
feat: add password strength meter to sign-up and change-password forms

### DIFF
--- a/app/_components/change-password-form.tsx
+++ b/app/_components/change-password-form.tsx
@@ -8,6 +8,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 
+import { PasswordStrengthMeter } from '@/app/_components/password-strength-meter';
 import { Button } from '@/app/_components/ui/button';
 import {
   Form,
@@ -24,10 +25,12 @@ const DataInput = ({
   value,
   onChange,
   label,
+  extra,
 }: {
   value: string;
   onChange: (s: string) => void;
   label: string;
+  extra?: React.ReactNode;
 }) => {
   return (
     <FormItem className="flex flex-col">
@@ -40,6 +43,7 @@ const DataInput = ({
           onChange={(e) => onChange(e.target.value)}
         />
       </FormControl>
+      {extra}
       <FormMessage />
     </FormItem>
   );
@@ -110,6 +114,7 @@ export function ChangePasswordForm({}: ChangePasswordFormProps) {
               value={field.value}
               onChange={field.onChange}
               label={t('newPassword')}
+              extra={<PasswordStrengthMeter password={field.value} />}
             />
           )}
         />

--- a/app/_components/password-strength-meter.tsx
+++ b/app/_components/password-strength-meter.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+import {
+  PASSWORD_STRENGTH_LABEL_KEYS,
+  PasswordStrengthScore,
+  getPasswordStrengthScore,
+} from '@/lib/password-strength';
+import { cn } from '@/lib/utils';
+
+const SEGMENT_COUNT = 5;
+
+const SCORE_COLOR_CLASSNAMES: Record<PasswordStrengthScore, string> = {
+  0: 'bg-destructive',
+  1: 'bg-destructive',
+  2: 'bg-yellow-500',
+  3: 'bg-blue-500',
+  4: 'bg-green-600',
+};
+
+type PasswordStrengthMeterProps = {
+  password: string;
+} & React.ComponentPropsWithoutRef<'div'>;
+
+export function PasswordStrengthMeter({
+  password,
+  className,
+  ...props
+}: PasswordStrengthMeterProps) {
+  const t = useTranslations();
+
+  if (!password) {
+    return null;
+  }
+
+  const score = getPasswordStrengthScore(password);
+  const litSegments = score + 1;
+
+  return (
+    <div
+      className={cn('flex flex-col gap-1', className)}
+      data-cy="password-strength-meter"
+      {...props}
+    >
+      <div className="flex gap-1">
+        {Array.from({ length: SEGMENT_COUNT }).map((_, index) => (
+          <div
+            key={index}
+            className={cn(
+              'h-1.5 flex-1 rounded-full transition-colors',
+              index < litSegments
+                ? SCORE_COLOR_CLASSNAMES[score]
+                : 'bg-primary/20'
+            )}
+          />
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground" aria-live="polite">
+        {`${t('passwordStrength')}: ${t(PASSWORD_STRENGTH_LABEL_KEYS[score])}`}
+      </p>
+    </div>
+  );
+}

--- a/app/_components/sign-up-form.tsx
+++ b/app/_components/sign-up-form.tsx
@@ -3,9 +3,10 @@
 import { Label } from '@radix-ui/react-label';
 import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { useTransition } from 'react';
+import { useState, useTransition } from 'react';
 import { toast } from 'sonner';
 
+import { PasswordStrengthMeter } from '@/app/_components/password-strength-meter';
 import { Button } from '@/app/_components/ui/button';
 import {
   Card,
@@ -26,6 +27,7 @@ export function SignUpForm({
 }: React.ComponentPropsWithoutRef<'div'>) {
   const t = useTranslations();
   const [loading, startTransition] = useTransition();
+  const [password, setPassword] = useState('');
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -73,7 +75,9 @@ export function SignUpForm({
                   id="password"
                   data-cy="password"
                   required
+                  onChange={(e) => setPassword(e.target.value)}
                 />
+                <PasswordStrengthMeter password={password} />
               </div>
               <div className="grid gap-2">
                 <div className="flex items-center">

--- a/lib/password-strength.ts
+++ b/lib/password-strength.ts
@@ -1,0 +1,124 @@
+// Lightweight, dependency-free password strength heuristic.
+//
+// Deliberately not using a library like zxcvbn here: this app's sign-up
+// page is covered by a Lighthouse CI performance budget
+// (categories:performance >= 0.7, see lighthouserc.js), and zxcvbn's
+// bundled dictionaries are large enough to put that at real risk for a
+// "nice to have" UI hint. This heuristic is simpler and won't catch
+// everything a dictionary-based tool would (e.g. leetspeak substitutions
+// like "P@ssw0rd"), but it's a reasonable, honest tradeoff for a
+// client-side-only strength *indicator* -- the real security boundary is
+// still server-side length validation (see the zod schemas), not this
+// meter.
+
+export type PasswordStrengthScore = 0 | 1 | 2 | 3 | 4;
+
+export const PASSWORD_STRENGTH_LABEL_KEYS: Record<
+  PasswordStrengthScore,
+  string
+> = {
+  0: 'passwordStrengthVeryWeak',
+  1: 'passwordStrengthWeak',
+  2: 'passwordStrengthFair',
+  3: 'passwordStrengthGood',
+  4: 'passwordStrengthStrong',
+};
+
+// A small, non-exhaustive list of the most commonly breached/guessed
+// passwords. Not meant to be comprehensive -- just enough to catch the
+// obvious cases without shipping a large wordlist.
+const COMMON_PASSWORDS = new Set([
+  'password',
+  'password1',
+  'p@ssword',
+  'p@ssw0rd',
+  'passw0rd',
+  '123456',
+  '12345678',
+  '123456789',
+  '1234567890',
+  'qwerty',
+  'qwerty123',
+  'letmein',
+  'welcome',
+  'welcome1',
+  'admin',
+  'administrator',
+  'iloveyou',
+  'monkey',
+  'dragon',
+  'football',
+  'baseball',
+  'trustno1',
+  'abc123',
+  '111111',
+  '123123',
+  'sunshine',
+  'master',
+  'shadow',
+  'superman',
+  'princess',
+  'starwars',
+]);
+
+const SEQUENTIAL_PATTERNS = [
+  '0123456789',
+  'abcdefghijklmnopqrstuvwxyz',
+  'qwertyuiop',
+  'asdfghjkl',
+  'zxcvbnm',
+];
+
+function hasSequentialRun(password: string, minRun = 4): boolean {
+  const lower = password.toLowerCase();
+  return SEQUENTIAL_PATTERNS.some((pattern) => {
+    for (let i = 0; i <= pattern.length - minRun; i++) {
+      const forward = pattern.slice(i, i + minRun);
+      const backward = [...forward].reverse().join('');
+      if (lower.includes(forward) || lower.includes(backward)) {
+        return true;
+      }
+    }
+    return false;
+  });
+}
+
+function isAllSameCharacter(password: string): boolean {
+  return password.length > 1 && new Set(password).size === 1;
+}
+
+export function getPasswordStrengthScore(
+  password: string
+): PasswordStrengthScore {
+  if (!password) {
+    return 0;
+  }
+
+  if (
+    isAllSameCharacter(password) ||
+    COMMON_PASSWORDS.has(password.toLowerCase())
+  ) {
+    return 0;
+  }
+
+  let score = 0;
+
+  const length = password.length;
+  if (length >= 8) score += 1;
+  if (length >= 10) score += 1;
+  if (length >= 14) score += 1;
+
+  let varietyCount = 0;
+  if (/[a-z]/.test(password)) varietyCount++;
+  if (/[A-Z]/.test(password)) varietyCount++;
+  if (/[0-9]/.test(password)) varietyCount++;
+  if (/[^a-zA-Z0-9]/.test(password)) varietyCount++;
+  if (varietyCount >= 3) score += 1;
+  if (varietyCount === 4) score += 1;
+
+  if (hasSequentialRun(password)) {
+    score -= 2;
+  }
+
+  return Math.max(0, Math.min(4, score)) as PasswordStrengthScore;
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -105,5 +105,11 @@
   "dangerZone": "Danger Zone",
   "deleteAccount": "Delete Account",
   "deleteAccountDescription": "Permanently delete your account, visa settings, and leave records. This action cannot be undone.",
-  "deleteAccountConfirmation": "This will permanently delete your account and all associated data. This action cannot be undone. Enter your password to confirm."
+  "deleteAccountConfirmation": "This will permanently delete your account and all associated data. This action cannot be undone. Enter your password to confirm.",
+  "passwordStrength": "Password strength",
+  "passwordStrengthVeryWeak": "Very weak",
+  "passwordStrengthWeak": "Weak",
+  "passwordStrengthFair": "Fair",
+  "passwordStrengthGood": "Good",
+  "passwordStrengthStrong": "Strong"
 }

--- a/messages/zh-Hant-HK.json
+++ b/messages/zh-Hant-HK.json
@@ -105,5 +105,11 @@
   "dangerZone": "危險區域",
   "deleteAccount": "刪除帳戶",
   "deleteAccountDescription": "永久刪除您的帳戶、簽證設定及離開記錄，此操作無法復原。",
-  "deleteAccountConfirmation": "此操作將永久刪除您的帳戶及所有相關資料，且無法復原。請輸入密碼以確認。"
+  "deleteAccountConfirmation": "此操作將永久刪除您的帳戶及所有相關資料，且無法復原。請輸入密碼以確認。",
+  "passwordStrength": "密碼強度",
+  "passwordStrengthVeryWeak": "非常弱",
+  "passwordStrengthWeak": "弱",
+  "passwordStrengthFair": "普通",
+  "passwordStrengthGood": "良好",
+  "passwordStrengthStrong": "強"
 }

--- a/tests/units/components/change-password-form.test.tsx
+++ b/tests/units/components/change-password-form.test.tsx
@@ -28,6 +28,23 @@ it('renders all three password fields and a submit button', () => {
   expect(screen.getByRole('button', { name: 'submit' })).toBeInTheDocument();
 });
 
+it('shows the password strength meter under newPassword as it is typed', async () => {
+  render(<ChangePasswordForm />);
+
+  expect(
+    screen.queryByText('passwordStrength:', { exact: false })
+  ).not.toBeInTheDocument();
+
+  await userEvent.type(
+    screen.getByLabelText('newPassword'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthStrong')
+  ).toBeInTheDocument();
+});
+
 it('shows pleaseInput under each field when submitted empty', async () => {
   render(<ChangePasswordForm />);
 

--- a/tests/units/components/password-strength-meter.test.tsx
+++ b/tests/units/components/password-strength-meter.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import { PasswordStrengthMeter } from '@/app/_components/password-strength-meter';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+it('renders nothing for an empty password', () => {
+  const { container } = render(<PasswordStrengthMeter password="" />);
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+it('shows the very-weak label for a common password', () => {
+  render(<PasswordStrengthMeter password="password" />);
+
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthVeryWeak')
+  ).toBeInTheDocument();
+});
+
+it('shows the strong label for a long password with full variety', () => {
+  render(<PasswordStrengthMeter password="Tr0ub4dor&Xk9mPqLz!" />);
+
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthStrong')
+  ).toBeInTheDocument();
+});
+
+it('updates the label as the password changes', () => {
+  const { rerender } = render(<PasswordStrengthMeter password="short1" />);
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthVeryWeak')
+  ).toBeInTheDocument();
+
+  rerender(<PasswordStrengthMeter password="Tr0ub4dor&Xk9mPqLz!" />);
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthStrong')
+  ).toBeInTheDocument();
+});

--- a/tests/units/components/sign-up-form.test.tsx
+++ b/tests/units/components/sign-up-form.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { toast } from 'sonner';
+import { expect, it, vi } from 'vitest';
+
+import { SignUpForm } from '@/app/_components/sign-up-form';
+import { authActions } from '@/app/actions';
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/app/actions', () => ({
+  authActions: { signUp: vi.fn() },
+}));
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+it('renders the email, password, and confirm password fields', () => {
+  render(<SignUpForm />);
+
+  expect(screen.getByLabelText('email')).toBeInTheDocument();
+  expect(screen.getByLabelText('password')).toBeInTheDocument();
+  expect(screen.getByLabelText('confirmPassword')).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: 'signUp' })).toBeInTheDocument();
+});
+
+it('does not show the password strength meter before typing a password', () => {
+  render(<SignUpForm />);
+
+  expect(
+    screen.queryByText('passwordStrength:', { exact: false })
+  ).not.toBeInTheDocument();
+});
+
+it('shows the password strength meter as the password field is typed into', async () => {
+  render(<SignUpForm />);
+
+  await userEvent.type(screen.getByLabelText('password'), 'password');
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthVeryWeak')
+  ).toBeInTheDocument();
+
+  await userEvent.clear(screen.getByLabelText('password'));
+  await userEvent.type(
+    screen.getByLabelText('password'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+  expect(
+    screen.getByText('passwordStrength: passwordStrengthStrong')
+  ).toBeInTheDocument();
+});
+
+it('does not show the strength meter for the confirm password field', async () => {
+  render(<SignUpForm />);
+
+  await userEvent.type(
+    screen.getByLabelText('confirmPassword'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+
+  expect(
+    screen.queryByText('passwordStrength:', { exact: false })
+  ).not.toBeInTheDocument();
+});
+
+it('calls authActions.signUp on submit', async () => {
+  // A successful sign-up redirects server-side and never resolves with a
+  // value the client sees; the mock is left unconfigured (resolves
+  // `undefined` by default) to match that.
+  render(<SignUpForm />);
+
+  await userEvent.type(screen.getByLabelText('email'), 'new@test.com');
+  await userEvent.type(
+    screen.getByLabelText('password'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+  await userEvent.type(
+    screen.getByLabelText('confirmPassword'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'signUp' }));
+
+  expect(authActions.signUp).toHaveBeenCalledTimes(1);
+});
+
+it('shows an error toast when the action returns an error', async () => {
+  vi.mocked(authActions.signUp).mockResolvedValue({ error: 'Email taken' });
+  render(<SignUpForm />);
+
+  await userEvent.type(screen.getByLabelText('email'), 'new@test.com');
+  await userEvent.type(
+    screen.getByLabelText('password'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+  await userEvent.type(
+    screen.getByLabelText('confirmPassword'),
+    'Tr0ub4dor&Xk9mPqLz!'
+  );
+  await userEvent.click(screen.getByRole('button', { name: 'signUp' }));
+
+  expect(toast.error).toHaveBeenCalledWith('Email taken');
+});

--- a/tests/units/lib/password-strength.test.ts
+++ b/tests/units/lib/password-strength.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPasswordStrengthScore } from '@/lib/password-strength';
+
+describe('getPasswordStrengthScore', () => {
+  it('returns 0 for an empty password', () => {
+    expect(getPasswordStrengthScore('')).toBe(0);
+  });
+
+  it('returns 0 for a common password regardless of length', () => {
+    expect(getPasswordStrengthScore('password')).toBe(0);
+    expect(getPasswordStrengthScore('Password1')).toBeLessThanOrEqual(2);
+    expect(getPasswordStrengthScore('qwerty123')).toBe(0);
+  });
+
+  it('returns 0 for a password made of a single repeated character', () => {
+    expect(getPasswordStrengthScore('aaaaaaaaaa')).toBe(0);
+  });
+
+  it('penalizes sequential runs like sequential letters or digits', () => {
+    expect(getPasswordStrengthScore('abcdefgh')).toBe(0);
+    expect(getPasswordStrengthScore('12345678')).toBe(0);
+  });
+
+  it('scores a short, single-character-class password low', () => {
+    expect(getPasswordStrengthScore('short1')).toBeLessThanOrEqual(1);
+  });
+
+  it('scores a longer password with some variety as fair or better', () => {
+    const score = getPasswordStrengthScore('Sunflower72');
+    expect(score).toBeGreaterThanOrEqual(2);
+  });
+
+  it('scores a long password with full character variety as strong', () => {
+    expect(getPasswordStrengthScore('Tr0ub4dor&Xk9mPqLz!')).toBe(4);
+  });
+
+  it('is deterministic for the same input', () => {
+    const password = 'Some-Reasonably-Good1';
+    expect(getPasswordStrengthScore(password)).toBe(
+      getPasswordStrengthScore(password)
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Frontend-only UX improvement, as requested. Adds a live strength meter with a text label under the "new password" field on both the sign-up form and the change-password form.

- **No new dependency.** Deliberately not using a dictionary-based library like zxcvbn: the sign-up page has a Lighthouse CI performance budget (`categories:performance >= 0.7`, see `lighthouserc.js`), and zxcvbn's bundled wordlists are large enough to put that at real risk for what's just a UI hint. Instead, `lib/password-strength.ts` is a small, pure, dependency-free heuristic (length, character-class variety, penalizing common passwords / sequential runs / all-same-character strings), independently unit tested.
- Won't catch everything a dictionary tool would (e.g. leetspeak substitutions like `P@ssw0rd`) — called out in a code comment. This is a client-side indicator only, not a security boundary; server-side length validation (existing zod schemas) is unchanged.
- `app/_components/password-strength-meter.tsx`: renders nothing for an empty password, otherwise a 5-segment color-coded bar plus a text label ("Password strength: Weak/Fair/Good/...").
- Wired into `sign-up-form.tsx`'s `password` field (previously an uncontrolled form — added local state solely to feed the meter; submission still reads from the DOM via `FormData` exactly as before) and `change-password-form.tsx`'s `newPassword` field only (not `confirmPassword`/`currentPassword`), via a new optional `extra` slot on that form's existing `DataInput` helper.
- Added strings for both locales (en, zh-Hant-HK).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `yarn lint` — clean (only pre-existing unrelated warnings)
- [x] `yarn vitest run` — 171/171 passing (19 new)
- [x] Unit tests for the scoring function across empty/common/sequential/repeated/weak/strong cases
- [x] Component tests for the meter itself (empty → renders nothing, weak/strong labels, updates on rerender)
- [x] New test file for `sign-up-form.tsx` (had no prior coverage) covering the meter's visibility and basic submit/error paths
- [x] Added assertion to the existing `change-password-form` test
- [ ] CI (lint/unit/e2e/lighthouse) green on this PR — worth double-checking the Lighthouse performance score on `/en/sign-up` specifically, given the reasoning above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live password strength feedback while creating or changing a password.
  * Introduced clearer strength labels and translations, with a visual strength bar that updates as you type.

* **Bug Fixes**
  * Improved password guidance for weak, repeated, common, and sequential passwords.
  * Password strength messaging now appears only when a password is entered.

* **Tests**
  * Added coverage for password strength scoring and form behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->