### PR TITLE
feat: add LRU eviction cap to InMemoryCacheStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ APP_URL=http://localhost:3000
 # Upstash Redis — L2 cache (optional; in-memory L1 is used when unset)
 UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
+
+# L1 in-memory cache size cap (entries, default 500)
+L1_CACHE_MAX=500

--- a/di/modules/cache.module.ts
+++ b/di/modules/cache.module.ts
@@ -11,7 +11,8 @@ const L1_CACHE_STORE = Symbol('L1CacheStore');
 export function createCacheModule() {
   const cacheModule = createModule();
 
-  cacheModule.bind(L1_CACHE_STORE).toClass(InMemoryCacheStore, []);
+  const l1Max = process.env.L1_CACHE_MAX ? parseInt(process.env.L1_CACHE_MAX, 10) : 500;
+  cacheModule.bind(L1_CACHE_STORE).toFactory(() => new InMemoryCacheStore(l1Max));
 
   cacheModule
     .bind(DI_SYMBOLS.ICacheManager)

--- a/src/infrastructure/services/cache-store.service.ts
+++ b/src/infrastructure/services/cache-store.service.ts
@@ -7,6 +7,11 @@ interface StoreEntry {
 
 export class InMemoryCacheStore implements ICacheStore {
   private readonly store = new Map<string, StoreEntry>();
+  private readonly max: number;
+
+  constructor(max = 500) {
+    this.max = max;
+  }
 
   getName(): string {
     return 'in-memory';
@@ -19,10 +24,22 @@ export class InMemoryCacheStore implements ICacheStore {
       this.store.delete(key);
       return undefined;
     }
+    // move to end = most-recently-used
+    this.store.delete(key);
+    this.store.set(key, entry);
     return entry.value as T;
   }
 
   async set<T>(key: string, value: T, ttlMs: number): Promise<void> {
+    if (this.store.size >= this.max && !this.store.has(key)) {
+      // evict least-recently-used (first key in insertion order)
+      const lruKey = this.store.keys().next().value;
+      if (lruKey !== undefined) {
+        this.store.delete(lruKey);
+      }
+    }
+    // delete then re-insert to update insertion position
+    this.store.delete(key);
     this.store.set(key, { value, expiresAt: Date.now() + ttlMs });
   }
 

--- a/tests/units/infrastructure/services/cache-store.service.test.ts
+++ b/tests/units/infrastructure/services/cache-store.service.test.ts
@@ -64,3 +64,50 @@ describe('InMemoryCacheStore', () => {
     await expect(store.get('session:1')).resolves.toBe('c');
   });
 });
+
+describe('InMemoryCacheStore – LRU eviction', () => {
+  it('evicts the least-recently-used entry when the cap is reached', async () => {
+    const store = new InMemoryCacheStore(3);
+    await store.set('a', 1, 60_000);
+    await store.set('b', 2, 60_000);
+    await store.set('c', 3, 60_000);
+
+    // adding a 4th entry evicts 'a' (oldest / LRU)
+    await store.set('d', 4, 60_000);
+
+    await expect(store.get('a')).resolves.toBeUndefined();
+    await expect(store.get('b')).resolves.toBe(2);
+    await expect(store.get('c')).resolves.toBe(3);
+    await expect(store.get('d')).resolves.toBe(4);
+  });
+
+  it('a get promotes the entry so it is not the next eviction target', async () => {
+    const store = new InMemoryCacheStore(3);
+    await store.set('a', 1, 60_000);
+    await store.set('b', 2, 60_000);
+    await store.set('c', 3, 60_000);
+
+    // touch 'a' — now 'b' is the LRU
+    await store.get('a');
+    await store.set('d', 4, 60_000);
+
+    await expect(store.get('b')).resolves.toBeUndefined(); // 'b' evicted
+    await expect(store.get('a')).resolves.toBe(1);
+    await expect(store.get('c')).resolves.toBe(3);
+    await expect(store.get('d')).resolves.toBe(4);
+  });
+
+  it('overwriting an existing key does not evict another entry', async () => {
+    const store = new InMemoryCacheStore(3);
+    await store.set('a', 1, 60_000);
+    await store.set('b', 2, 60_000);
+    await store.set('c', 3, 60_000);
+
+    // overwriting 'a' does not evict because the store is not growing
+    await store.set('a', 99, 60_000);
+
+    await expect(store.get('a')).resolves.toBe(99);
+    await expect(store.get('b')).resolves.toBe(2);
+    await expect(store.get('c')).resolves.toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a `max` constructor option to `InMemoryCacheStore` (default 500 entries, configurable via `L1_CACHE_MAX`)
- Uses `Map` insertion-order for O(1) LRU: `get` moves a key to the end (most-recently-used); `set` evicts the first key (least-recently-used) when at capacity
- Overwriting an existing key never triggers eviction — the store count doesn't grow

## Test plan
- [ ] Fill store to capacity, add one more entry — confirm oldest key is evicted
- [ ] Touch a key via `get`, then fill to trigger eviction — confirm the touched key survives
- [ ] Overwrite a key at capacity — confirm no other entry is evicted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for the in-memory cache size, with a new default capacity of 500 entries.
  * The cache now behaves more like an LRU store, keeping recently accessed items available for longer.

* **Bug Fixes**
  * Updated cache handling so that reading an item refreshes its position and full caches evict the least recently used entry.
  * Overwriting an existing cached value now updates it without removing other entries unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->