### PR TITLE
feat: add proactive expiry sweep to InMemoryCacheStore

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,6 @@ UPSTASH_REDIS_REST_TOKEN=
 
 # L1 in-memory cache size cap (entries, default 500)
 L1_CACHE_MAX=500
+
+# L1 proactive expiry sweep interval in ms (default 60000; set to 0 to disable)
+L1_CACHE_SWEEP_MS=60000

--- a/di/modules/cache.module.ts
+++ b/di/modules/cache.module.ts
@@ -12,7 +12,8 @@ export function createCacheModule() {
   const cacheModule = createModule();
 
   const l1Max = process.env.L1_CACHE_MAX ? parseInt(process.env.L1_CACHE_MAX, 10) : 500;
-  cacheModule.bind(L1_CACHE_STORE).toFactory(() => new InMemoryCacheStore(l1Max));
+  const l1Sweep = process.env.L1_CACHE_SWEEP_MS ? parseInt(process.env.L1_CACHE_SWEEP_MS, 10) : 60_000;
+  cacheModule.bind(L1_CACHE_STORE).toFactory(() => new InMemoryCacheStore(l1Max, l1Sweep));
 
   cacheModule
     .bind(DI_SYMBOLS.ICacheManager)

--- a/src/infrastructure/services/cache-store.service.ts
+++ b/src/infrastructure/services/cache-store.service.ts
@@ -9,12 +9,28 @@ export class InMemoryCacheStore implements ICacheStore {
   private readonly store = new Map<string, StoreEntry>();
   private readonly max: number;
 
-  constructor(max = 500) {
+  constructor(max = 500, sweepIntervalMs = 60_000) {
     this.max = max;
+    if (sweepIntervalMs > 0) {
+      const timer = setInterval(() => this.purgeExpired(), sweepIntervalMs);
+      // Don't prevent the Node.js process from exiting cleanly
+      if (typeof timer === 'object' && timer !== null && 'unref' in timer) {
+        (timer as NodeJS.Timeout).unref();
+      }
+    }
   }
 
   getName(): string {
     return 'in-memory';
+  }
+
+  purgeExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.store) {
+      if (now > entry.expiresAt) {
+        this.store.delete(key);
+      }
+    }
   }
 
   async get<T>(key: string): Promise<T | undefined> {

--- a/tests/units/infrastructure/services/cache-store.service.test.ts
+++ b/tests/units/infrastructure/services/cache-store.service.test.ts
@@ -65,6 +65,42 @@ describe('InMemoryCacheStore', () => {
   });
 });
 
+describe('InMemoryCacheStore – proactive expiry sweep', () => {
+  it('purgeExpired removes expired entries without touching live ones', async () => {
+    const store = new InMemoryCacheStore(500, 0); // sweep disabled — call manually
+    await store.set('live', 'keep', 60_000);
+    await store.set('dead', 'gone', 1);
+
+    await new Promise((r) => setTimeout(r, 10)); // let 'dead' expire
+
+    store.purgeExpired();
+
+    await expect(store.get('dead')).resolves.toBeUndefined();
+    await expect(store.get('live')).resolves.toBe('keep');
+  });
+
+  it('purgeExpired is a no-op on an empty store', () => {
+    const store = new InMemoryCacheStore(500, 0);
+    expect(() => store.purgeExpired()).not.toThrow();
+  });
+
+  it('purgeExpired frees capacity so new entries can be added without LRU eviction', async () => {
+    const store = new InMemoryCacheStore(2, 0); // cap of 2
+    await store.set('a', 1, 1); // expires immediately
+    await store.set('b', 2, 60_000);
+
+    await new Promise((r) => setTimeout(r, 10)); // 'a' expires
+
+    store.purgeExpired(); // should free one slot
+
+    // 'c' can now be added without evicting 'b'
+    await store.set('c', 3, 60_000);
+
+    await expect(store.get('b')).resolves.toBe(2);
+    await expect(store.get('c')).resolves.toBe(3);
+  });
+});
+
 describe('InMemoryCacheStore – LRU eviction', () => {
   it('evicts the least-recently-used entry when the cap is reached', async () => {
     const store = new InMemoryCacheStore(3);


### PR DESCRIPTION
## Summary
- Adds `purgeExpired()` to `InMemoryCacheStore` — scans all entries and removes those past `expiresAt`
- A background `setInterval` (default 60 s, `L1_CACHE_SWEEP_MS` env var, set to `0` to disable) calls it automatically
- Timer is `.unref()`'d so it never prevents a clean Node.js process exit

## Why
Without this, entries that are written but never read again accumulate indefinitely. The LRU cap only evicts on write; the sweep handles the idle-key case.

## Test plan
- [ ] Write an entry with a 1 ms TTL, wait, call `purgeExpired()` — confirm it's gone
- [ ] Confirm live entries are untouched
- [ ] Confirm freed capacity lets new entries in without triggering LRU eviction