### PR TITLE
feat: cross-instance L1 invalidation via Upstash Redis sorted set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,6 @@ L1_CACHE_MAX=500
 
 # L1 proactive expiry sweep interval in ms (default 60000; set to 0 to disable)
 L1_CACHE_SWEEP_MS=60000
+
+# Cross-instance L1 invalidation poll interval in ms (default 5000; requires Upstash Redis)
+L1_INVALIDATION_POLL_MS=5000

--- a/di/modules/cache.module.ts
+++ b/di/modules/cache.module.ts
@@ -1,7 +1,9 @@
+import { Redis } from '@upstash/redis';
 import { createModule } from '@evyweb/ioctopus';
 
 import { DI_SYMBOLS } from '@/di/types';
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
+import { UpstashInvalidationRelay } from '@/src/infrastructure/services/cache-invalidation-relay.service';
 import { CacheManager } from '@/src/infrastructure/services/cache-manager.service';
 import { UpstashRedisCacheStore } from '@/src/infrastructure/services/cache-store.upstash-redis.service';
 import { InMemoryCacheStore } from '@/src/infrastructure/services/cache-store.service';
@@ -18,12 +20,28 @@ export function createCacheModule() {
   cacheModule
     .bind(DI_SYMBOLS.ICacheManager)
     .toFactory((resolve: (key: symbol | string) => unknown) => {
-      const l1 = resolve(L1_CACHE_STORE) as ICacheStore;
+      const l1 = resolve(L1_CACHE_STORE) as InMemoryCacheStore;
       const url = process.env.UPSTASH_REDIS_REST_URL;
       const token = process.env.UPSTASH_REDIS_REST_TOKEN;
       const l2 =
         url && token ? new UpstashRedisCacheStore(url, token) : undefined;
-      return new CacheManager(l1, l2);
+
+      const pollMs = process.env.L1_INVALIDATION_POLL_MS
+        ? parseInt(process.env.L1_INVALIDATION_POLL_MS, 10)
+        : 5_000;
+      const relay =
+        url && token
+          ? new UpstashInvalidationRelay(new Redis({ url, token }))
+          : undefined;
+
+      if (relay) {
+        relay.subscribe((event) => {
+          if (event.type === 'key') void l1.delete(event.key);
+          if (event.type === 'prefix') void l1.deleteByPrefix(event.prefix);
+        }, pollMs);
+      }
+
+      return new CacheManager(l1, l2, relay);
     });
 
   return cacheModule;

--- a/src/application/services/cache-invalidation-relay.service.interface.ts
+++ b/src/application/services/cache-invalidation-relay.service.interface.ts
@@ -1,0 +1,12 @@
+export type InvalidationEvent =
+  | { type: 'key'; key: string }
+  | { type: 'prefix'; prefix: string };
+
+export interface ICacheInvalidationRelay {
+  publish(event: InvalidationEvent): Promise<void>;
+  subscribe(
+    handler: (event: InvalidationEvent) => void,
+    pollIntervalMs?: number
+  ): void;
+  close(): void;
+}

--- a/src/infrastructure/services/cache-invalidation-relay.service.ts
+++ b/src/infrastructure/services/cache-invalidation-relay.service.ts
@@ -1,0 +1,70 @@
+import { Redis } from '@upstash/redis';
+
+import {
+  ICacheInvalidationRelay,
+  InvalidationEvent,
+} from '@/src/application/services/cache-invalidation-relay.service.interface';
+
+const RELAY_KEY = 'l1:invalidation-events';
+// Keep events for 5 minutes — long enough for any poll cycle to catch them
+const RETENTION_MS = 5 * 60 * 1000;
+
+export class UpstashInvalidationRelay implements ICacheInvalidationRelay {
+  private lastPollMs = Date.now();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(private readonly redis: Redis) {}
+
+  async publish(event: InvalidationEvent): Promise<void> {
+    const now = Date.now();
+    // Unique member: timestamp prefix guarantees ordering; random suffix avoids
+    // collisions when multiple instances publish at the same millisecond
+    const member = `${now}-${Math.random().toString(36).slice(2)}:${JSON.stringify(event)}`;
+
+    await Promise.allSettled([
+      this.redis.zadd(RELAY_KEY, { score: now, member }),
+      this.redis.zremrangebyscore(RELAY_KEY, '-inf', now - RETENTION_MS),
+    ]);
+  }
+
+  subscribe(
+    handler: (event: InvalidationEvent) => void,
+    pollIntervalMs = 5_000
+  ): void {
+    const poll = async () => {
+      const since = this.lastPollMs;
+      this.lastPollMs = Date.now();
+      try {
+        const members = await this.redis.zrange<string[]>(
+          RELAY_KEY,
+          since,
+          '+inf',
+          { byScore: true }
+        );
+        for (const member of members) {
+          const colonIdx = member.indexOf(':');
+          if (colonIdx === -1) continue;
+          try {
+            handler(JSON.parse(member.slice(colonIdx + 1)) as InvalidationEvent);
+          } catch {
+            // ignore malformed events
+          }
+        }
+      } catch {
+        // ignore transient poll failures — next tick will retry
+      }
+    };
+
+    this.pollTimer = setInterval(() => void poll(), pollIntervalMs);
+    if (this.pollTimer && typeof this.pollTimer === 'object' && 'unref' in this.pollTimer) {
+      (this.pollTimer as NodeJS.Timeout).unref();
+    }
+  }
+
+  close(): void {
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+  }
+}

--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -2,6 +2,7 @@ import {
   CacheOptions,
   ICacheManager,
 } from '@/src/application/services/cache-manager.service.interface';
+import { ICacheInvalidationRelay } from '@/src/application/services/cache-invalidation-relay.service.interface';
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
 
 interface CachedEntry<T> {
@@ -52,7 +53,8 @@ export class CacheManager implements ICacheManager {
 
   constructor(
     private readonly l1: ICacheStore,
-    private readonly l2?: ICacheStore
+    private readonly l2?: ICacheStore,
+    private readonly relay?: ICacheInvalidationRelay
   ) {}
 
   async get<T>(
@@ -195,6 +197,7 @@ export class CacheManager implements ICacheManager {
     await Promise.allSettled([
       this.l1.delete(key),
       this.l2 ? this.l2.delete(key) : Promise.resolve(),
+      this.relay ? this.relay.publish({ type: 'key', key }) : Promise.resolve(),
     ]);
   }
 
@@ -202,6 +205,9 @@ export class CacheManager implements ICacheManager {
     await Promise.allSettled([
       this.l1.deleteByPrefix(prefix),
       this.l2 ? this.l2.deleteByPrefix(prefix) : Promise.resolve(),
+      this.relay
+        ? this.relay.publish({ type: 'prefix', prefix })
+        : Promise.resolve(),
     ]);
   }
 }

--- a/tests/units/infrastructure/services/cache-invalidation-relay.service.test.ts
+++ b/tests/units/infrastructure/services/cache-invalidation-relay.service.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockRedis = vi.hoisted(() => ({
+  zadd: vi.fn(),
+  zremrangebyscore: vi.fn(),
+  zrange: vi.fn(),
+}));
+
+vi.mock('@upstash/redis', () => ({
+  Redis: class {
+    zadd = mockRedis.zadd;
+    zremrangebyscore = mockRedis.zremrangebyscore;
+    zrange = mockRedis.zrange;
+  },
+}));
+
+import { InvalidationEvent } from '@/src/application/services/cache-invalidation-relay.service.interface';
+import { UpstashInvalidationRelay } from '@/src/infrastructure/services/cache-invalidation-relay.service';
+import { Redis } from '@upstash/redis';
+
+function makeRelay() {
+  return new UpstashInvalidationRelay(new Redis({ url: 'http://x', token: 't' }));
+}
+
+describe('UpstashInvalidationRelay', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis.zadd.mockResolvedValue(1);
+    mockRedis.zremrangebyscore.mockResolvedValue(0);
+    mockRedis.zrange.mockResolvedValue([]);
+  });
+
+  describe('publish', () => {
+    it('adds the event to the sorted set with a timestamp score', async () => {
+      const relay = makeRelay();
+      await relay.publish({ type: 'key', key: 'user:1' });
+
+      expect(mockRedis.zadd).toHaveBeenCalledOnce();
+      const [key, { score, member }] = mockRedis.zadd.mock.calls[0];
+      expect(key).toBe('l1:invalidation-events');
+      expect(typeof score).toBe('number');
+      expect(member).toContain(JSON.stringify({ type: 'key', key: 'user:1' }));
+    });
+
+    it('trims events older than the retention window on each publish', async () => {
+      const relay = makeRelay();
+      await relay.publish({ type: 'prefix', prefix: 'user:' });
+      expect(mockRedis.zremrangebyscore).toHaveBeenCalledOnce();
+      const [key, min] = mockRedis.zremrangebyscore.mock.calls[0];
+      expect(key).toBe('l1:invalidation-events');
+      expect(min).toBe('-inf');
+    });
+  });
+
+  describe('subscribe / poll', () => {
+    it('calls the handler for each event returned by zrange', async () => {
+      vi.useFakeTimers();
+      const relay = makeRelay();
+
+      const event: InvalidationEvent = { type: 'key', key: 'session:abc' };
+      const rawMember = `1234567890-abc:${JSON.stringify(event)}`;
+      mockRedis.zrange.mockResolvedValue([rawMember]);
+
+      const handler = vi.fn();
+      relay.subscribe(handler, 100);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler).toHaveBeenCalledWith(event);
+
+      relay.close();
+      vi.useRealTimers();
+    });
+
+    it('skips malformed members without throwing', async () => {
+      vi.useFakeTimers();
+      const relay = makeRelay();
+      mockRedis.zrange.mockResolvedValue(['no-colon-here', 'also-bad']);
+
+      const handler = vi.fn();
+      relay.subscribe(handler, 100);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(handler).not.toHaveBeenCalled();
+
+      relay.close();
+      vi.useRealTimers();
+    });
+
+    it('silently ignores poll failures', async () => {
+      vi.useFakeTimers();
+      const relay = makeRelay();
+      mockRedis.zrange.mockRejectedValue(new Error('network error'));
+
+      const handler = vi.fn();
+      relay.subscribe(handler, 100);
+
+      await expect(vi.advanceTimersByTimeAsync(100)).resolves.not.toThrow();
+
+      relay.close();
+      vi.useRealTimers();
+    });
+  });
+
+  describe('close', () => {
+    it('stops the poll interval', async () => {
+      vi.useFakeTimers();
+      const relay = makeRelay();
+      const handler = vi.fn();
+      relay.subscribe(handler, 100);
+
+      relay.close();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(mockRedis.zrange).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/tests/units/infrastructure/services/cache-manager.service.test.ts
+++ b/tests/units/infrastructure/services/cache-manager.service.test.ts
@@ -191,3 +191,38 @@ describe('CacheManager – L1 + L2', () => {
     expect(fetcher).toHaveBeenCalledTimes(2); // re-fetched from scratch
   });
 });
+
+describe('CacheManager – relay', () => {
+  function makeRelay() {
+    return {
+      publish: vi.fn().mockResolvedValue(undefined),
+      subscribe: vi.fn(),
+      close: vi.fn(),
+    };
+  }
+
+  it('publishes a key event when invalidate is called', async () => {
+    const relay = makeRelay();
+    const manager = new CacheManager(new InMemoryCacheStore(), undefined, relay);
+
+    await manager.invalidate('user:1');
+
+    expect(relay.publish).toHaveBeenCalledWith({ type: 'key', key: 'user:1' });
+  });
+
+  it('publishes a prefix event when invalidateByPrefix is called', async () => {
+    const relay = makeRelay();
+    const manager = new CacheManager(new InMemoryCacheStore(), undefined, relay);
+
+    await manager.invalidateByPrefix('user:');
+
+    expect(relay.publish).toHaveBeenCalledWith({ type: 'prefix', prefix: 'user:' });
+  });
+
+  it('does not publish when no relay is configured', async () => {
+    // just verify no error thrown — relay is undefined
+    const manager = new CacheManager(new InMemoryCacheStore());
+    await expect(manager.invalidate('k')).resolves.toBeUndefined();
+    await expect(manager.invalidateByPrefix('k:')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- `UpstashInvalidationRelay` publishes key/prefix invalidation events to a Redis sorted set (`l1:invalidation-events`) with a millisecond timestamp score
- Each app instance polls every 5 s (`L1_INVALIDATION_POLL_MS`) using `ZRANGE BYSCORE since last_poll` and clears its own L1 on receipt — no cross-instance state needed
- Events are trimmed after 5 minutes on each publish to keep the set bounded
- `CacheManager` accepts the relay as an optional third constructor arg; no relay = existing behaviour unchanged
- The relay is only created when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are set

## Design note
`SUBSCRIBE` requires a persistent TCP connection which is unavailable over Upstash's HTTP REST API. The sorted-set poll approach works in both long-running Node.js and serverless deployments.

## Test plan
- [ ] Deploy two instances, invalidate a key on one, confirm the other's L1 is cleared within one poll interval
- [ ] Confirm no relay activity when Upstash env vars are absent
- [ ] Confirm `L1_INVALIDATION_POLL_MS=0` can be used to disable polling