### PR TITLE
fix: resolve boundaries lint errors from MCP server

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,11 @@ const eslintConfig = [
         },
         {
           mode: 'full',
+          type: 'mcp',
+          pattern: ['src/interface-adapters/mcp/**/*'],
+        },
+        {
+          mode: 'full',
           type: 'di',
           pattern: ['di/**/*'],
         },
@@ -88,7 +93,11 @@ const eslintConfig = [
           rules: [
             {
               from: 'web',
-              allow: ['web', 'entities', 'di'],
+              allow: ['web', 'entities', 'di', 'mcp'],
+            },
+            {
+              from: 'mcp',
+              allow: ['mcp', 'entities', 'di'],
             },
             {
               from: 'controllers',

--- a/src/interface-adapters/mcp/tools/user-settings.ts
+++ b/src/interface-adapters/mcp/tools/user-settings.ts
@@ -3,7 +3,6 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { getInjection } from '@/di/container';
 import { getVisaStatus } from '@/lib/visa';
-import { NotFoundError } from '@/src/entities/errors/common';
 
 const updateUserSettingsShape = {
   visaStartDate: z.string().optional().describe('ISO 8601 date'),

--- a/src/interface-adapters/mcp/tools/users.ts
+++ b/src/interface-adapters/mcp/tools/users.ts
@@ -8,8 +8,8 @@ type McpResult = { content: { type: 'text'; text: string }[]; isError?: boolean 
 export async function getUserHandler(userId: string): Promise<McpResult> {
   try {
     const user = await getInjection('IGetUserUseCase')(userId);
-    const { passwordHash: _, ...safeUser } = user;
-    return { content: [{ type: 'text', text: JSON.stringify(safeUser) }] };
+    const { id, email, emailVerified } = user;
+    return { content: [{ type: 'text', text: JSON.stringify({ id, email, emailVerified }) }] };
   } catch (err) {
     if (err instanceof NotFoundError) {
       return {


### PR DESCRIPTION
## Summary

- Registers `mcp` as a known element type in the `eslint-plugin-boundaries` config (`src/interface-adapters/mcp/**/*`)
- Adds allow rules: `mcp → mcp`, `mcp → entities`, `mcp → di`, `web → mcp`
- Removes unused `NotFoundError` import in `user-settings.ts`
- Replaces the `passwordHash: _` destructure in `users.ts` with explicit field selection (`{ id, email, emailVerified }`) to clear the `no-unused-vars` warning

## Test plan

- [ ] `yarn lint` passes with 0 errors
- [ ] `yarn test` still passes (8 MCP tests green)
- [ ] CI passes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new MCP integration area, with updated dependency rules to allow it to work alongside existing app layers.

* **Bug Fixes**
  * User details responses now return only the expected public fields, reducing the chance of exposing extra account information.
  * Cleaned up an unused error reference in one of the MCP tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->