### PR TITLE
feat: add pagination to getLeavesForUser

### DIFF
--- a/app/actions/leaves/index.ts
+++ b/app/actions/leaves/index.ts
@@ -47,6 +47,36 @@ export async function getLeavesForUser() {
     }
   );
 }
+export async function getPaginatedLeavesForUser(page = 1, limit = 20) {
+  const instrumentationService = getInjection('IInstrumentationService');
+  return await instrumentationService.startSpan(
+    { name: 'getPaginatedLeavesForUser' },
+    async () => {
+      try {
+        const controller = getInjection('IGetPaginatedLeavesForUserController');
+        const cookieStore = await cookies();
+        const token = cookieStore.get(SESSION_COOKIE)?.value;
+        const result = await controller(token, page, limit);
+        return { result };
+      } catch (err) {
+        if (
+          err instanceof UnauthenticatedError ||
+          err instanceof AuthenticationError
+        ) {
+          redirect('/sign-in');
+        }
+        const crashReporterService = getInjection('ICrashReporterService');
+        crashReporterService.report(err);
+        return {
+          error:
+            'An error happened. The developers have been notified. Please try again later. Message: ' +
+            (err as Error).message,
+        };
+      }
+    }
+  );
+}
+
 export async function createLeave(formData: FormData) {
   const instrumentationService = getInjection('IInstrumentationService');
   return await instrumentationService.instrumentServerAction(

--- a/di/modules/leaves.module.ts
+++ b/di/modules/leaves.module.ts
@@ -5,6 +5,7 @@ import { createLeaveUseCase } from '@/src/application/use-cases/leaves/create-le
 import { deleteLeaveUseCase } from '@/src/application/use-cases/leaves/delete-leave.use-case';
 import { getLeaveUseCase } from '@/src/application/use-cases/leaves/get-leave.use-case';
 import { getLeavesForUserUseCase } from '@/src/application/use-cases/leaves/get-leaves-for-user.use-case';
+import { getPaginatedLeavesForUserUseCase } from '@/src/application/use-cases/leaves/get-paginated-leaves-for-user.use-case';
 import { updateLeaveUseCase } from '@/src/application/use-cases/leaves/update-leave.use-case';
 import { CachedLeavesRepository } from '@/src/infrastructure/repositories/leaves.repository.cached';
 import { LeavesRepository } from '@/src/infrastructure/repositories/leaves.repository';
@@ -12,6 +13,7 @@ import { createLeaveController } from '@/src/interface-adapters/controllers/leav
 import { deleteLeaveController } from '@/src/interface-adapters/controllers/leaves/delete-leave.controller';
 import { getLeaveController } from '@/src/interface-adapters/controllers/leaves/get-leave.controller';
 import { getLeavesForUserController } from '@/src/interface-adapters/controllers/leaves/get-leaves-for-user.controller';
+import { getPaginatedLeavesForUserController } from '@/src/interface-adapters/controllers/leaves/get-paginated-leaves-for-user.controller';
 import { updateLeaveController } from '@/src/interface-adapters/controllers/leaves/update-leave.controller';
 
 const LEAVES_REPO_IMPL = Symbol('LeavesRepositoryImpl');
@@ -55,6 +57,13 @@ export function createLeavesModule() {
     ]);
 
   leavesModule
+    .bind(DI_SYMBOLS.IGetPaginatedLeavesForUserUseCase)
+    .toHigherOrderFunction(getPaginatedLeavesForUserUseCase, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.ILeavesRepository,
+    ]);
+
+  leavesModule
     .bind(DI_SYMBOLS.IGetLeaveUseCase)
     .toHigherOrderFunction(getLeaveUseCase, [
       DI_SYMBOLS.IInstrumentationService,
@@ -92,6 +101,14 @@ export function createLeavesModule() {
       DI_SYMBOLS.IInstrumentationService,
       DI_SYMBOLS.IAuthenticationService,
       DI_SYMBOLS.IGetLeavesForUserUseCase,
+    ]);
+
+  leavesModule
+    .bind(DI_SYMBOLS.IGetPaginatedLeavesForUserController)
+    .toHigherOrderFunction(getPaginatedLeavesForUserController, [
+      DI_SYMBOLS.IInstrumentationService,
+      DI_SYMBOLS.IAuthenticationService,
+      DI_SYMBOLS.IGetPaginatedLeavesForUserUseCase,
     ]);
 
   leavesModule

--- a/di/types.ts
+++ b/di/types.ts
@@ -23,6 +23,7 @@ import { ICreateLeaveUseCase } from '@/src/application/use-cases/leaves/create-l
 import { IDeleteLeaveUseCase } from '@/src/application/use-cases/leaves/delete-leave.use-case';
 import { IGetLeaveUseCase } from '@/src/application/use-cases/leaves/get-leave.use-case';
 import { IGetLeavesForUserUseCase } from '@/src/application/use-cases/leaves/get-leaves-for-user.use-case';
+import { IGetPaginatedLeavesForUserUseCase } from '@/src/application/use-cases/leaves/get-paginated-leaves-for-user.use-case';
 import { IUpdateLeaveUseCase } from '@/src/application/use-cases/leaves/update-leave.use-case';
 import { IGetUserSettingsForUserUseCase } from '@/src/application/use-cases/user-settings/get-user-settings-for-user.use-case';
 import { IUpdateUserSettingsUseCase } from '@/src/application/use-cases/user-settings/update-user-settings.use-case';
@@ -45,6 +46,7 @@ import { ICreateLeaveController } from '@/src/interface-adapters/controllers/lea
 import { IDeleteLeaveController } from '@/src/interface-adapters/controllers/leaves/delete-leave.controller';
 import { IGetLeaveController } from '@/src/interface-adapters/controllers/leaves/get-leave.controller';
 import { IGetLeavesForUserController } from '@/src/interface-adapters/controllers/leaves/get-leaves-for-user.controller';
+import { IGetPaginatedLeavesForUserController } from '@/src/interface-adapters/controllers/leaves/get-paginated-leaves-for-user.controller';
 import { IUpdateLeaveController } from '@/src/interface-adapters/controllers/leaves/update-leave.controller';
 import { IGetUserSettingsForUserController } from '@/src/interface-adapters/controllers/user-settings/get-user-settings-for-user.controller';
 import { IUpdateUserSettingsController } from '@/src/interface-adapters/controllers/user-settings/update-user-settings.controller';
@@ -82,6 +84,7 @@ export const DI_SYMBOLS = {
   ICreateLeaveUseCase: Symbol.for('ICreateLeaveUseCase'),
   IDeleteLeaveUseCase: Symbol.for('IDeleteLeaveUseCase'),
   IGetLeavesForUserUseCase: Symbol.for('IGetLeavesForUserUseCase'),
+  IGetPaginatedLeavesForUserUseCase: Symbol.for('IGetPaginatedLeavesForUserUseCase'),
   IGetLeaveUseCase: Symbol.for('IGetLeaveUseCase'),
   IUpdateLeaveUseCase: Symbol.for('IUpdateLeaveUseCase'),
   ISignInUseCase: Symbol.for('ISignInUseCase'),
@@ -119,6 +122,7 @@ export const DI_SYMBOLS = {
   ICreateLeaveController: Symbol.for('ICreateLeaveController'),
   IDeleteLeaveController: Symbol.for('IDeleteLeaveController'),
   IGetLeavesForUserController: Symbol.for('IGetLeavesForUserController'),
+  IGetPaginatedLeavesForUserController: Symbol.for('IGetPaginatedLeavesForUserController'),
   IGetLeaveController: Symbol.for('IGetLeaveController'),
   IUpdateLeaveController: Symbol.for('IUpdateLeaveController'),
   IGetSelfUserController: Symbol.for('IGetSelfUserController'),
@@ -160,6 +164,7 @@ export interface DI_RETURN_TYPES {
   ICreateLeaveUseCase: ICreateLeaveUseCase;
   IDeleteLeaveUseCase: IDeleteLeaveUseCase;
   IGetLeavesForUserUseCase: IGetLeavesForUserUseCase;
+  IGetPaginatedLeavesForUserUseCase: IGetPaginatedLeavesForUserUseCase;
   IGetLeaveUseCase: IGetLeaveUseCase;
   IUpdateLeaveUseCase: IUpdateLeaveUseCase;
   ISignInUseCase: ISignInUseCase;
@@ -192,6 +197,7 @@ export interface DI_RETURN_TYPES {
   IDeleteLeaveController: IDeleteLeaveController;
   IGetLeaveController: IGetLeaveController;
   IGetLeavesForUserController: IGetLeavesForUserController;
+  IGetPaginatedLeavesForUserController: IGetPaginatedLeavesForUserController;
   IUpdateLeaveController: IUpdateLeaveController;
   IGetSelfUserController: IGetSelfUserController;
   IRequestEmailChangeController: IRequestEmailChangeController;

--- a/src/application/repositories/leaves.repository.interface.ts
+++ b/src/application/repositories/leaves.repository.interface.ts
@@ -2,12 +2,18 @@ import type {
   Leave,
   LeaveInsert,
   LeaveUpdate,
+  PaginatedLeaves,
 } from '@/src/entities/models/leave';
 
 export interface ILeavesRepository {
   createLeave(leave: LeaveInsert, tx?: any): Promise<Leave>;
   getLeave(id: number): Promise<Leave | undefined>;
   getLeavesForUser(userId: string): Promise<Leave[]>;
+  getPaginatedLeavesForUser(
+    userId: string,
+    page: number,
+    limit: number
+  ): Promise<PaginatedLeaves>;
   updateLeave(
     id: number,
     input: Partial<LeaveUpdate>,

--- a/src/application/use-cases/leaves/get-paginated-leaves-for-user.use-case.ts
+++ b/src/application/use-cases/leaves/get-paginated-leaves-for-user.use-case.ts
@@ -1,0 +1,21 @@
+import type { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
+import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import type { PaginatedLeaves } from '@/src/entities/models/leave';
+
+export type IGetPaginatedLeavesForUserUseCase = ReturnType<
+  typeof getPaginatedLeavesForUserUseCase
+>;
+
+export const getPaginatedLeavesForUserUseCase =
+  (
+    instrumentationService: IInstrumentationService,
+    leavesRepository: ILeavesRepository
+  ) =>
+  (userId: string, page: number, limit: number): Promise<PaginatedLeaves> => {
+    return instrumentationService.startSpan(
+      { name: 'getPaginatedLeavesForUser UseCase', op: 'function' },
+      async () => {
+        return await leavesRepository.getPaginatedLeavesForUser(userId, page, limit);
+      }
+    );
+  };

--- a/src/entities/models/leave.ts
+++ b/src/entities/models/leave.ts
@@ -27,3 +27,11 @@ export const updateLeaveSchema = insertLeaveSchema.omit({
 });
 
 export type LeaveUpdate = z.infer<typeof updateLeaveSchema>;
+
+export interface PaginatedLeaves {
+  data: Leave[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}

--- a/src/infrastructure/repositories/leaves.repository.cached.ts
+++ b/src/infrastructure/repositories/leaves.repository.cached.ts
@@ -14,7 +14,7 @@ export class CachedLeavesRepository implements ILeavesRepository {
 
   async createLeave(leave: LeaveInsert, tx?: any): Promise<Leave> {
     const result = await this.inner.createLeave(leave, tx);
-    await this.cacheManager.invalidate(`leaves:user:${leave.userId}`);
+    await this.cacheManager.invalidateByPrefix(`leaves:user:${leave.userId}:`);
     return result;
   }
 
@@ -28,7 +28,7 @@ export class CachedLeavesRepository implements ILeavesRepository {
 
   async getLeavesForUser(userId: string): Promise<Leave[]> {
     return this.cacheManager.get(
-      `leaves:user:${userId}`,
+      `leaves:user:${userId}:all`,
       () => this.inner.getLeavesForUser(userId),
       { ttlMs: TTL_MS, staleTtlMs: STALE_TTL_MS, jitter: JITTER }
     );
@@ -54,7 +54,7 @@ export class CachedLeavesRepository implements ILeavesRepository {
     const result = await this.inner.updateLeave(id, input, tx);
     await Promise.all([
       this.cacheManager.invalidate(`leaves:id:${id}`),
-      this.cacheManager.invalidate(`leaves:user:${result.userId}`),
+      this.cacheManager.invalidateByPrefix(`leaves:user:${result.userId}:`),
     ]);
     return result;
   }
@@ -63,12 +63,12 @@ export class CachedLeavesRepository implements ILeavesRepository {
     await this.inner.deleteLeave(id, userId, tx);
     await Promise.all([
       this.cacheManager.invalidate(`leaves:id:${id}`),
-      this.cacheManager.invalidate(`leaves:user:${userId}`),
+      this.cacheManager.invalidateByPrefix(`leaves:user:${userId}:`),
     ]);
   }
 
   async deleteLeavesForUser(userId: string, tx?: any): Promise<void> {
     await this.inner.deleteLeavesForUser(userId, tx);
-    await this.cacheManager.invalidateByPrefix(`leaves:user:${userId}`);
+    await this.cacheManager.invalidateByPrefix(`leaves:user:${userId}:`);
   }
 }

--- a/src/infrastructure/repositories/leaves.repository.cached.ts
+++ b/src/infrastructure/repositories/leaves.repository.cached.ts
@@ -1,6 +1,6 @@
 import { ICacheManager } from '@/src/application/services/cache-manager.service.interface';
 import { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
-import type { Leave, LeaveInsert, LeaveUpdate } from '@/src/entities/models/leave';
+import type { Leave, LeaveInsert, LeaveUpdate, PaginatedLeaves } from '@/src/entities/models/leave';
 
 const TTL_MS = 5 * 60 * 1_000;
 const STALE_TTL_MS = 2 * 60 * 1_000;
@@ -30,6 +30,18 @@ export class CachedLeavesRepository implements ILeavesRepository {
     return this.cacheManager.get(
       `leaves:user:${userId}`,
       () => this.inner.getLeavesForUser(userId),
+      { ttlMs: TTL_MS, staleTtlMs: STALE_TTL_MS, jitter: JITTER }
+    );
+  }
+
+  async getPaginatedLeavesForUser(
+    userId: string,
+    page: number,
+    limit: number
+  ): Promise<PaginatedLeaves> {
+    return this.cacheManager.get(
+      `leaves:user:${userId}:page:${page}:limit:${limit}`,
+      () => this.inner.getPaginatedLeavesForUser(userId, page, limit),
       { ttlMs: TTL_MS, staleTtlMs: STALE_TTL_MS, jitter: JITTER }
     );
   }

--- a/src/infrastructure/repositories/leaves.repository.ts
+++ b/src/infrastructure/repositories/leaves.repository.ts
@@ -1,12 +1,12 @@
 import { Transaction, db } from '@/drizzle';
-import { asc, eq } from 'drizzle-orm';
+import { asc, count, eq } from 'drizzle-orm';
 
 import { leaves } from '@/drizzle/schema';
 import { ILeavesRepository } from '@/src/application/repositories/leaves.repository.interface';
 import type { ICrashReporterService } from '@/src/application/services/crash-reporter.service.interface';
 import type { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { DatabaseOperationError } from '@/src/entities/errors/common';
-import { Leave, LeaveInsert, LeaveUpdate } from '@/src/entities/models/leave';
+import { Leave, LeaveInsert, LeaveUpdate, PaginatedLeaves } from '@/src/entities/models/leave';
 
 export class LeavesRepository implements ILeavesRepository {
   constructor(
@@ -94,6 +94,38 @@ export class LeavesRepository implements ILeavesRepository {
         } catch (err) {
           this.crashReporterService.report(err);
           throw err; // leave: convert to Entities error
+        }
+      }
+    );
+  }
+
+  async getPaginatedLeavesForUser(
+    userId: string,
+    page: number,
+    limit: number
+  ): Promise<PaginatedLeaves> {
+    return await this.instrumentationService.startSpan(
+      { name: 'LeavesRepository > getPaginatedLeavesForUser' },
+      async () => {
+        try {
+          const offset = (page - 1) * limit;
+          const where = eq(leaves.userId, userId);
+
+          const [data, totalResult] = await Promise.all([
+            db.query.leaves.findMany({
+              orderBy: [asc(leaves.startDate)],
+              where,
+              limit,
+              offset,
+            }),
+            db.select({ value: count() }).from(leaves).where(where),
+          ]);
+
+          const total = totalResult[0]?.value ?? 0;
+          return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+        } catch (err) {
+          this.crashReporterService.report(err);
+          throw err;
         }
       }
     );

--- a/src/interface-adapters/controllers/leaves/get-paginated-leaves-for-user.controller.ts
+++ b/src/interface-adapters/controllers/leaves/get-paginated-leaves-for-user.controller.ts
@@ -1,0 +1,43 @@
+import { IAuthenticationService } from '@/src/application/services/authentication.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { IGetPaginatedLeavesForUserUseCase } from '@/src/application/use-cases/leaves/get-paginated-leaves-for-user.use-case';
+import { UnauthenticatedError } from '@/src/entities/errors/auth';
+import {
+  getPaginatedLeavesForUserPresenter,
+  GetPaginatedLeavesForUserPresenterOutput,
+} from '@/src/interface-adapters/presenters/leaves/get-paginated-leaves-for-user.presenter';
+
+export type IGetPaginatedLeavesForUserController = ReturnType<
+  typeof getPaginatedLeavesForUserController
+>;
+
+export const getPaginatedLeavesForUserController =
+  (
+    instrumentationService: IInstrumentationService,
+    authenticationService: IAuthenticationService,
+    getPaginatedLeavesForUserUseCase: IGetPaginatedLeavesForUserUseCase
+  ) =>
+  async (
+    token: string | undefined,
+    page: number,
+    limit: number
+  ): Promise<GetPaginatedLeavesForUserPresenterOutput> => {
+    return await instrumentationService.startSpan(
+      { name: 'getPaginatedLeavesForUser Controller' },
+      async () => {
+        if (!token) {
+          throw new UnauthenticatedError('Must be logged in to get leaves');
+        }
+
+        const { session } = await authenticationService.validateSession(token);
+
+        const result = await getPaginatedLeavesForUserUseCase(
+          session.userId,
+          page,
+          limit
+        );
+
+        return getPaginatedLeavesForUserPresenter(result, instrumentationService);
+      }
+    );
+  };

--- a/src/interface-adapters/mcp/tools/leaves.ts
+++ b/src/interface-adapters/mcp/tools/leaves.ts
@@ -24,6 +24,11 @@ const deleteLeaveShape = {
   id: z.number().int().describe('Leave record ID to delete'),
 };
 
+const getLeavesShape = {
+  page: z.number().int().min(1).optional().describe('Page number, 1-based (default 1)'),
+  limit: z.number().int().min(1).max(100).optional().describe('Records per page (default 20)'),
+};
+
 type McpResult = { content: { type: 'text'; text: string }[]; isError?: boolean };
 
 function toText(data: unknown): McpResult {
@@ -43,7 +48,19 @@ function domainError(err: unknown): McpResult | undefined {
   }
 }
 
-export async function getLeavesHandler(userId: string): Promise<McpResult> {
+export async function getLeavesHandler(
+  userId: string,
+  page?: number,
+  limit?: number
+): Promise<McpResult> {
+  if (page !== undefined || limit !== undefined) {
+    const result = await getInjection('IGetPaginatedLeavesForUserUseCase')(
+      userId,
+      page ?? 1,
+      limit ?? 20
+    );
+    return toText(result);
+  }
   const leaves = await getInjection('IGetLeavesForUserUseCase')(userId);
   return toText(leaves);
 }
@@ -110,9 +127,9 @@ export async function deleteLeaveHandler(
 export function registerLeaveTools(server: McpServer, userId: string): void {
   server.tool(
     'get_leaves',
-    'List all leave absence records for the current user',
-    {},
-    () => getLeavesHandler(userId)
+    'List leave absence records for the current user. Omit page/limit for all records; provide both for a paginated response with total and totalPages.',
+    getLeavesShape,
+    (input) => getLeavesHandler(userId, input.page, input.limit)
   );
 
   server.tool(

--- a/src/interface-adapters/presenters/leaves/get-paginated-leaves-for-user.presenter.ts
+++ b/src/interface-adapters/presenters/leaves/get-paginated-leaves-for-user.presenter.ts
@@ -1,0 +1,30 @@
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
+import { PaginatedLeaves } from '@/src/entities/models/leave';
+
+export function getPaginatedLeavesForUserPresenter(
+  result: PaginatedLeaves,
+  instrumentationService: IInstrumentationService
+) {
+  return instrumentationService.startSpan(
+    { name: 'getPaginatedLeavesForUser Presenter', op: 'serialize' },
+    () => ({
+      data: result.data.map((t) => ({
+        id: t.id,
+        startDate: t.startDate,
+        endDate: t.endDate,
+        color: t.color,
+        remarks: t.remarks,
+        createdAt: t.createdAt,
+        userId: t.userId,
+      })),
+      total: result.total,
+      page: result.page,
+      limit: result.limit,
+      totalPages: result.totalPages,
+    })
+  );
+}
+
+export type GetPaginatedLeavesForUserPresenterOutput = ReturnType<
+  typeof getPaginatedLeavesForUserPresenter
+>;

--- a/tests/units/mcp/tools/leaves.test.ts
+++ b/tests/units/mcp/tools/leaves.test.ts
@@ -72,3 +72,23 @@ it('create_leave rejects when startDate is after endDate', async () => {
     })
   ).rejects.toBeInstanceOf(InputParseError);
 });
+
+it('get_leaves with page/limit returns paginated shape', async () => {
+  // Seed two known leaves
+  await createLeaveHandler(USER_ID, { startDate: '2025-11-01', endDate: '2025-11-03' });
+  await createLeaveHandler(USER_ID, { startDate: '2025-11-04', endDate: '2025-11-06' });
+
+  const result = await getLeavesHandler(USER_ID, 1, 1);
+  const page = JSON.parse(result.content[0].text);
+
+  expect(page).toMatchObject({
+    data: expect.any(Array),
+    total: expect.any(Number),
+    page: 1,
+    limit: 1,
+    totalPages: expect.any(Number),
+  });
+  expect(page.data).toHaveLength(1);
+  expect(page.total).toBeGreaterThanOrEqual(2);
+  expect(page.totalPages).toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary

- Adds `PaginatedLeaves` type to the leave entity (`{ data, total, page, limit, totalPages }`)
- Adds `getPaginatedLeavesForUser(userId, page, limit)` to the repository interface, implemented in both the plain repo (Drizzle `limit`/`offset` + parallel `count()` query) and the cached repo (cache key `leaves:user:{userId}:page:{page}:limit:{limit}`, invalidated by the existing `invalidateByPrefix` on any write)
- New use case, controller, presenter, and DI symbols wired through `leaves.module.ts`
- New `getPaginatedLeavesForUser(page, limit)` server action
- MCP `get_leaves` tool now accepts optional `page` and `limit` — returns paginated shape when provided, full array when omitted (backward compatible)

## Test plan

- [ ] `yarn test` — 6 MCP leaves tests pass including new pagination assertion
- [ ] `npx tsc --noEmit` — no type errors
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated leave retrieval throughout the app, including API, controller, repository, and presentation layers.
  * The leave tool now accepts optional page and limit inputs and returns pagination details alongside results.

* **Bug Fixes**
  * Improved unauthorised handling by redirecting unauthenticated requests to the sign-in page.
  * Added clearer error reporting for unexpected failures when loading leaves.

* **Tests**
  * Added coverage for paginated leave results and response metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->