### PR TITLE
fix: respect circuit breaker in cache invalidation

### DIFF
--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -195,16 +195,16 @@ export class CacheManager implements ICacheManager {
 
   async invalidate(key: string): Promise<void> {
     await Promise.allSettled([
-      this.l1.delete(key),
-      this.l2 ? this.l2.delete(key) : Promise.resolve(),
+      this.l1Breaker.isOpen() ? Promise.resolve() : this.l1.delete(key),
+      this.l2 && !this.l2Breaker.isOpen() ? this.l2.delete(key) : Promise.resolve(),
       this.relay ? this.relay.publish({ type: 'key', key }) : Promise.resolve(),
     ]);
   }
 
   async invalidateByPrefix(prefix: string): Promise<void> {
     await Promise.allSettled([
-      this.l1.deleteByPrefix(prefix),
-      this.l2 ? this.l2.deleteByPrefix(prefix) : Promise.resolve(),
+      this.l1Breaker.isOpen() ? Promise.resolve() : this.l1.deleteByPrefix(prefix),
+      this.l2 && !this.l2Breaker.isOpen() ? this.l2.deleteByPrefix(prefix) : Promise.resolve(),
       this.relay
         ? this.relay.publish({ type: 'prefix', prefix })
         : Promise.resolve(),


### PR DESCRIPTION
## Summary

`invalidate` and `invalidateByPrefix` were calling L1/L2 directly without checking the circuit breaker, so a degraded store would still receive delete calls that fail silently — leaving stale entries that won't get swept.

Both methods now skip a store when its breaker is OPEN, matching the behaviour of the read path.

## Test plan
- [ ] `yarn test` passes
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache invalidation now respects cache availability, avoiding deletion attempts when a cache layer is unavailable.
  * Invalidation events are still published as normal, so cache updates continue to propagate consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->