### PR TITLE
fix: circuit breaker HALF_OPEN gates to a single probe request

### DIFF
--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -15,6 +15,7 @@ class CircuitBreaker {
   private failures = 0;
   private openedAt = 0;
   private state: 'CLOSED' | 'OPEN' | 'HALF_OPEN' = 'CLOSED';
+  private probing = false;
 
   constructor(
     private readonly failureThreshold = 5,
@@ -25,19 +26,33 @@ class CircuitBreaker {
     if (this.state === 'OPEN') {
       if (Date.now() - this.openedAt >= this.recoveryTimeMs) {
         this.state = 'HALF_OPEN';
-        return false;
+        this.probing = false;
+      } else {
+        return true;
       }
-      return true;
+    }
+    if (this.state === 'HALF_OPEN') {
+      if (this.probing) return true; // one probe in flight — block all others
+      this.probing = true;           // claim the probe slot
+      return false;
     }
     return false;
   }
 
   recordSuccess(): void {
     this.failures = 0;
+    this.probing = false;
     this.state = 'CLOSED';
   }
 
   recordFailure(): void {
+    this.probing = false;
+    if (this.state === 'HALF_OPEN') {
+      // probe failed — re-open immediately without waiting for threshold
+      this.state = 'OPEN';
+      this.openedAt = Date.now();
+      return;
+    }
     this.failures++;
     if (this.failures >= this.failureThreshold) {
       this.state = 'OPEN';


### PR DESCRIPTION
## Summary

The `CircuitBreaker.isOpen()` previously transitioned to HALF_OPEN and immediately returned `false`, letting all concurrent requests through at once. A still-degraded store would then re-trip the breaker on all of them simultaneously.

A `probing` boolean now claims the probe slot for the first request in HALF_OPEN; all others are treated as OPEN and blocked. On probe success → CLOSED. On probe failure → re-OPEN immediately (no need to wait for the failure threshold again).

## Test plan
- [ ] `yarn test` passes
- [ ] CI passes