### PR TITLE
feat: add cache hit/miss/error metrics via instrumentation service

### DIFF
--- a/di/modules/cache.module.ts
+++ b/di/modules/cache.module.ts
@@ -3,6 +3,7 @@ import { createModule } from '@evyweb/ioctopus';
 
 import { DI_SYMBOLS } from '@/di/types';
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 import { UpstashInvalidationRelay } from '@/src/infrastructure/services/cache-invalidation-relay.service';
 import { CacheManager } from '@/src/infrastructure/services/cache-manager.service';
 import { UpstashRedisCacheStore } from '@/src/infrastructure/services/cache-store.upstash-redis.service';
@@ -21,6 +22,7 @@ export function createCacheModule() {
     .bind(DI_SYMBOLS.ICacheManager)
     .toFactory((resolve: (key: symbol | string) => unknown) => {
       const l1 = resolve(L1_CACHE_STORE) as InMemoryCacheStore;
+      const instrumentation = resolve(DI_SYMBOLS.IInstrumentationService) as IInstrumentationService;
       const url = process.env.UPSTASH_REDIS_REST_URL;
       const token = process.env.UPSTASH_REDIS_REST_TOKEN;
       const l2 =
@@ -41,7 +43,7 @@ export function createCacheModule() {
         }, pollMs);
       }
 
-      return new CacheManager(l1, l2, relay);
+      return new CacheManager(l1, l2, relay, instrumentation);
     });
 
   return cacheModule;

--- a/src/application/services/instrumentation.service.interface.ts
+++ b/src/application/services/instrumentation.service.interface.ts
@@ -8,4 +8,5 @@ export interface IInstrumentationService {
     options: Record<string, any>,
     callback: () => T
   ): Promise<T>;
+  recordMetric(name: string, tags?: Record<string, string>): void;
 }

--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -4,6 +4,7 @@ import {
 } from '@/src/application/services/cache-manager.service.interface';
 import { ICacheInvalidationRelay } from '@/src/application/services/cache-invalidation-relay.service.interface';
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
+import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 
 interface CachedEntry<T> {
   data: T;
@@ -54,7 +55,8 @@ export class CacheManager implements ICacheManager {
   constructor(
     private readonly l1: ICacheStore,
     private readonly l2?: ICacheStore,
-    private readonly relay?: ICacheInvalidationRelay
+    private readonly relay?: ICacheInvalidationRelay,
+    private readonly instrumentation?: IInstrumentationService
   ) {}
 
   async get<T>(
@@ -69,15 +71,18 @@ export class CacheManager implements ICacheManager {
         if (entry) {
           const now = Date.now();
           if (now < entry.freshUntil) {
+            this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'fresh' });
             return entry.data;
           }
           if (now < entry.staleUntil) {
+            this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'stale' });
             this.triggerRevalidation(key, fetcher, options);
             return entry.data;
           }
         }
       } catch {
         this.l1Breaker.recordFailure();
+        this.instrumentation?.recordMetric('cache.error', { store: 'l1' });
       }
     }
 
@@ -90,17 +95,21 @@ export class CacheManager implements ICacheManager {
           if (now < entry.staleUntil) {
             void this.setInStore(this.l1, key, entry, entry.staleUntil - now);
             if (now < entry.freshUntil) {
+              this.instrumentation?.recordMetric('cache.hit', { store: 'l2', type: 'fresh' });
               return entry.data;
             }
+            this.instrumentation?.recordMetric('cache.hit', { store: 'l2', type: 'stale' });
             this.triggerRevalidation(key, fetcher, options);
             return entry.data;
           }
         }
       } catch {
         this.l2Breaker.recordFailure();
+        this.instrumentation?.recordMetric('cache.error', { store: 'l2' });
       }
     }
 
+    this.instrumentation?.recordMetric('cache.miss');
     return this.fetchWithCoalescing(key, fetcher, options);
   }
 

--- a/src/infrastructure/services/instrumentation.service.ts
+++ b/src/infrastructure/services/instrumentation.service.ts
@@ -17,4 +17,8 @@ export class InstrumentationService implements IInstrumentationService {
   ): Promise<T> {
     return Sentry.withServerActionInstrumentation(name, options, callback);
   }
+
+  recordMetric(name: string, tags?: Record<string, string>): void {
+    Sentry.metrics.count(name, 1, { attributes: tags });
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `recordMetric(name, tags?)` to `IInstrumentationService` (and its Sentry implementation via `Sentry.metrics.count`)
- `CacheManager.get` now records `cache.hit` (tagged `store: l1|l2`, `type: fresh|stale`), `cache.miss`, and `cache.error` (tagged `store: l1|l2`) on every call
- `CacheManager` accepts instrumentation as an optional fourth constructor arg — wired in `cache.module.ts`, zero impact on existing tests

## Test plan
- [ ] `yarn test` passes (no test changes needed — instrumentation is optional)
- [ ] CI passes
- [ ] Sentry dashboard shows `cache.hit`, `cache.miss`, `cache.error` counters under Metrics