### PR TITLE
fix: distributed lock prevents multi-instance thundering herd on cache miss

### DIFF
--- a/di/modules/cache.module.ts
+++ b/di/modules/cache.module.ts
@@ -8,6 +8,7 @@ import { UpstashInvalidationRelay } from '@/src/infrastructure/services/cache-in
 import { CacheManager } from '@/src/infrastructure/services/cache-manager.service';
 import { UpstashRedisCacheStore } from '@/src/infrastructure/services/cache-store.upstash-redis.service';
 import { InMemoryCacheStore } from '@/src/infrastructure/services/cache-store.service';
+import { UpstashDistributedLockService } from '@/src/infrastructure/services/distributed-lock.service';
 
 const L1_CACHE_STORE = Symbol('L1CacheStore');
 
@@ -31,10 +32,14 @@ export function createCacheModule() {
       const pollMs = process.env.L1_INVALIDATION_POLL_MS
         ? parseInt(process.env.L1_INVALIDATION_POLL_MS, 10)
         : 5_000;
-      const relay =
-        url && token
-          ? new UpstashInvalidationRelay(new Redis({ url, token }))
-          : undefined;
+
+      let redis: Redis | undefined;
+      if (url && token) {
+        redis = new Redis({ url, token });
+      }
+
+      const relay = redis ? new UpstashInvalidationRelay(redis) : undefined;
+      const lockService = redis ? new UpstashDistributedLockService(redis) : undefined;
 
       if (relay) {
         relay.subscribe((event) => {
@@ -43,7 +48,7 @@ export function createCacheModule() {
         }, pollMs);
       }
 
-      return new CacheManager(l1, l2, relay, instrumentation);
+      return new CacheManager(l1, l2, relay, lockService, instrumentation);
     });
 
   return cacheModule;

--- a/src/application/services/distributed-lock.service.interface.ts
+++ b/src/application/services/distributed-lock.service.interface.ts
@@ -1,0 +1,6 @@
+export interface IDistributedLockService {
+  /** Returns a token if the lock was acquired, null if already held. */
+  tryAcquire(key: string, ttlMs: number): Promise<string | null>;
+  /** Releases the lock only if the token matches (atomic check-and-delete). */
+  release(key: string, token: string): Promise<void>;
+}

--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -4,6 +4,7 @@ import {
 } from '@/src/application/services/cache-manager.service.interface';
 import { ICacheInvalidationRelay } from '@/src/application/services/cache-invalidation-relay.service.interface';
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
+import { IDistributedLockService } from '@/src/application/services/distributed-lock.service.interface';
 import { IInstrumentationService } from '@/src/application/services/instrumentation.service.interface';
 
 interface CachedEntry<T> {
@@ -71,6 +72,7 @@ export class CacheManager implements ICacheManager {
     private readonly l1: ICacheStore,
     private readonly l2?: ICacheStore,
     private readonly relay?: ICacheInvalidationRelay,
+    private readonly lockService?: IDistributedLockService,
     private readonly instrumentation?: IInstrumentationService
   ) {}
 
@@ -128,7 +130,7 @@ export class CacheManager implements ICacheManager {
     return this.fetchWithCoalescing(key, fetcher, options);
   }
 
-  private fetchWithCoalescing<T>(
+  private async fetchWithCoalescing<T>(
     key: string,
     fetcher: () => Promise<T>,
     options: CacheOptions
@@ -143,7 +145,53 @@ export class CacheManager implements ICacheManager {
         ),
       ]).catch(() => this.startFetch(key, fetcher, options));
     }
+
+    if (this.lockService) {
+      const lockKey = `dlock:${key}`;
+      // TTL is generous — covers fetch + write with headroom
+      const lockTtlMs = options.ttlMs + 5_000;
+      const token = await this.lockService.tryAcquire(lockKey, lockTtlMs);
+
+      if (!token) {
+        // Another instance holds the lock — wait, then try reading the cache
+        const waitMs = options.lockTimeoutMs ?? 100;
+        await new Promise<void>((r) => setTimeout(r, waitMs));
+        const cached = await this.readFromCacheOnly<T>(key);
+        if (cached !== undefined) return cached;
+        // Cache still empty after wait — do a local fetch without coordination
+      } else {
+        // We hold the distributed lock; release it once the write completes
+        const result = this.startFetch(key, fetcher, options);
+        result
+          .then(() => this.lockService!.release(lockKey, token))
+          .catch(() => {});
+        return result;
+      }
+    }
+
     return this.startFetch(key, fetcher, options);
+  }
+
+  private async readFromCacheOnly<T>(key: string): Promise<T | undefined> {
+    if (!this.l1Breaker.isOpen()) {
+      try {
+        const entry = await this.l1.get<CachedEntry<T>>(key);
+        this.l1Breaker.recordSuccess();
+        if (entry && Date.now() < entry.staleUntil) return entry.data;
+      } catch {
+        this.l1Breaker.recordFailure();
+      }
+    }
+    if (this.l2 && !this.l2Breaker.isOpen()) {
+      try {
+        const entry = await this.l2.get<CachedEntry<T>>(key);
+        this.l2Breaker.recordSuccess();
+        if (entry && Date.now() < entry.staleUntil) return entry.data;
+      } catch {
+        this.l2Breaker.recordFailure();
+      }
+    }
+    return undefined;
   }
 
   private startFetch<T>(

--- a/src/infrastructure/services/distributed-lock.service.ts
+++ b/src/infrastructure/services/distributed-lock.service.ts
@@ -1,0 +1,30 @@
+import { Redis } from '@upstash/redis';
+
+import { IDistributedLockService } from '@/src/application/services/distributed-lock.service.interface';
+
+// Atomic check-and-delete: only releases the lock if the stored token matches.
+const RELEASE_SCRIPT = `
+  if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+  else
+    return 0
+  end
+`;
+
+export class UpstashDistributedLockService implements IDistributedLockService {
+  private readonly releaseScript;
+
+  constructor(private readonly redis: Redis) {
+    this.releaseScript = redis.createScript<number>(RELEASE_SCRIPT);
+  }
+
+  async tryAcquire(key: string, ttlMs: number): Promise<string | null> {
+    const token = crypto.randomUUID();
+    const result = await this.redis.set(key, token, { nx: true, px: ttlMs });
+    return result === 'OK' ? token : null;
+  }
+
+  async release(key: string, token: string): Promise<void> {
+    await this.releaseScript.eval([key], [token]);
+  }
+}


### PR DESCRIPTION
## Summary

On a cache miss, concurrent requests from different server instances all run the fetcher simultaneously (the in-process `inFlight` coalescing only helps within a single process). This adds a Redis `SET NX PX` distributed lock before the fetcher runs:

- **Lock acquired**: run fetcher → write to cache → release lock (atomic Lua check-and-delete)
- **Lock not acquired**: wait `lockTimeoutMs` (default 100ms), re-read cache — the lock holder likely populated it; if still empty, fall back to local fetch rather than blocking indefinitely
- **Redis unavailable**: `lockService` is `undefined`, falls back to existing in-process coalescing only
- **Lock TTL**: `ttlMs + 5000ms` — ensures expiry even if the lock-holding process crashes mid-fetch

The `IDistributedLockService` interface is separate from the store interfaces so the implementation can be swapped.

## Test plan
- [ ] `yarn test` passes (no test changes needed — lock service is optional)
- [ ] CI passes
- [ ] Verify lock key `dlock:leaves:user:*` appears transiently in Redis on cold-cache requests