### PR TITLE
fix: atomic deleteByPrefix via Lua eliminates SCAN-then-DEL race

### DIFF
--- a/src/infrastructure/services/cache-store.upstash-redis.service.ts
+++ b/src/infrastructure/services/cache-store.upstash-redis.service.ts
@@ -2,11 +2,29 @@ import { Redis } from '@upstash/redis';
 
 import { ICacheStore } from '@/src/application/services/cache-store.service.interface';
 
+// Scan and delete all keys matching a glob pattern atomically.
+// Lua runs atomically in Redis — no other commands execute between SCAN and DEL,
+// so keys written concurrently cannot slip through between the two operations.
+const DELETE_BY_PATTERN_SCRIPT = `
+  local cursor = "0"
+  repeat
+    local result = redis.call("SCAN", cursor, "MATCH", ARGV[1], "COUNT", 100)
+    cursor = result[1]
+    local keys = result[2]
+    if #keys > 0 then
+      redis.call("DEL", unpack(keys))
+    end
+  until cursor == "0"
+  return 1
+`;
+
 export class UpstashRedisCacheStore implements ICacheStore {
   private readonly client: Redis;
+  private readonly deleteByPatternScript;
 
   constructor(url: string, token: string) {
     this.client = new Redis({ url, token });
+    this.deleteByPatternScript = this.client.createScript<number>(DELETE_BY_PATTERN_SCRIPT);
   }
 
   getName(): string {
@@ -27,16 +45,6 @@ export class UpstashRedisCacheStore implements ICacheStore {
   }
 
   async deleteByPrefix(prefix: string): Promise<void> {
-    let cursor = '0';
-    do {
-      const [nextCursor, keys] = await this.client.scan(cursor, {
-        match: `${prefix}*`,
-        count: 100,
-      });
-      cursor = nextCursor;
-      if (keys.length > 0) {
-        await this.client.del(...keys);
-      }
-    } while (cursor !== '0');
+    await this.deleteByPatternScript.eval([], [`${prefix}*`]);
   }
 }

--- a/tests/units/infrastructure/services/cache-store.upstash-redis.service.test.ts
+++ b/tests/units/infrastructure/services/cache-store.upstash-redis.service.test.ts
@@ -1,12 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // vi.hoisted ensures these are initialised before vi.mock() runs
-const mockRedis = vi.hoisted(() => ({
-  get: vi.fn(),
-  set: vi.fn(),
-  del: vi.fn(),
-  scan: vi.fn(),
-}));
+const { mockRedis, mockScript } = vi.hoisted(() => {
+  const mockScript = { eval: vi.fn() };
+  return {
+    mockScript,
+    mockRedis: {
+      get: vi.fn(),
+      set: vi.fn(),
+      del: vi.fn(),
+      scan: vi.fn(),
+      createScript: vi.fn().mockReturnValue(mockScript),
+    },
+  };
+});
 
 vi.mock('@upstash/redis', () => ({
   // Class-style mock so `new Redis(...)` is valid and instances carry the mock methods
@@ -15,6 +22,7 @@ vi.mock('@upstash/redis', () => ({
     set = mockRedis.set;
     del = mockRedis.del;
     scan = mockRedis.scan;
+    createScript = mockRedis.createScript;
   },
 }));
 
@@ -55,30 +63,15 @@ describe('UpstashRedisCacheStore', () => {
     expect(mockRedis.del).toHaveBeenCalledWith('k');
   });
 
-  it('deleteByPrefix scans all pages and deletes every matching key', async () => {
-    mockRedis.scan
-      .mockResolvedValueOnce(['42', ['user:1', 'user:2']])
-      .mockResolvedValueOnce(['0', ['user:3']]);
-    mockRedis.del.mockResolvedValue(3);
-
+  it('deleteByPrefix calls the Lua script with the glob pattern', async () => {
+    mockScript.eval.mockResolvedValue(1);
     await store.deleteByPrefix('user:');
-
-    expect(mockRedis.scan).toHaveBeenCalledTimes(2);
-    expect(mockRedis.scan).toHaveBeenNthCalledWith(1, '0', {
-      match: 'user:*',
-      count: 100,
-    });
-    expect(mockRedis.scan).toHaveBeenNthCalledWith(2, '42', {
-      match: 'user:*',
-      count: 100,
-    });
-    expect(mockRedis.del).toHaveBeenCalledWith('user:1', 'user:2');
-    expect(mockRedis.del).toHaveBeenCalledWith('user:3');
+    expect(mockScript.eval).toHaveBeenCalledWith([], ['user:*']);
   });
 
-  it('deleteByPrefix skips del when the scan returns no keys', async () => {
-    mockRedis.scan.mockResolvedValueOnce(['0', []]);
-    await store.deleteByPrefix('empty:');
-    expect(mockRedis.del).not.toHaveBeenCalled();
+  it('deleteByPrefix passes the correct glob for any prefix', async () => {
+    mockScript.eval.mockResolvedValue(1);
+    await store.deleteByPrefix('leaves:user:42:');
+    expect(mockScript.eval).toHaveBeenCalledWith([], ['leaves:user:42:*']);
   });
 });


### PR DESCRIPTION
## Summary

`deleteByPrefix` previously used a SCAN+DEL loop across multiple round trips. Between the last SCAN page and the final DEL:
- Newly written cache entries matching the prefix could slip through undeleted (leaving stale data)
- Concurrently written entries could be incorrectly deleted (spurious cache miss)

A single Lua script now handles the full scan-and-delete cycle. Lua scripts execute atomically in Redis — no other command can run between a SCAN page and its corresponding DEL. The compiled script is stored per-instance via `redis.createScript()`.

No functional changes to the public `ICacheStore` interface.

## Test plan
- [ ] `yarn test` passes
- [ ] CI passes
- [ ] Verify that after a leave update, subsequent `getLeavesForUser` gets fresh data with no stale-hit window