### PR TITLE
refactor: remove L1 circuit breaker from CacheManager

### DIFF
--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -65,7 +65,6 @@ class CircuitBreaker {
 
 export class CacheManager implements ICacheManager {
   private readonly inFlight = new Map<string, Promise<unknown>>();
-  private readonly l1Breaker = new CircuitBreaker();
   private readonly l2Breaker = new CircuitBreaker();
 
   constructor(
@@ -81,25 +80,17 @@ export class CacheManager implements ICacheManager {
     fetcher: () => Promise<T>,
     options: CacheOptions
   ): Promise<T> {
-    if (!this.l1Breaker.isOpen()) {
-      try {
-        const entry = await this.l1.get<CachedEntry<T>>(key);
-        this.l1Breaker.recordSuccess();
-        if (entry) {
-          const now = Date.now();
-          if (now < entry.freshUntil) {
-            this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'fresh' });
-            return entry.data;
-          }
-          if (now < entry.staleUntil) {
-            this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'stale' });
-            this.triggerRevalidation(key, fetcher, options);
-            return entry.data;
-          }
-        }
-      } catch {
-        this.l1Breaker.recordFailure();
-        this.instrumentation?.recordMetric('cache.error', { store: 'l1' });
+    const l1Entry = await this.l1.get<CachedEntry<T>>(key);
+    if (l1Entry) {
+      const now = Date.now();
+      if (now < l1Entry.freshUntil) {
+        this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'fresh' });
+        return l1Entry.data;
+      }
+      if (now < l1Entry.staleUntil) {
+        this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'stale' });
+        this.triggerRevalidation(key, fetcher, options);
+        return l1Entry.data;
       }
     }
 
@@ -173,15 +164,8 @@ export class CacheManager implements ICacheManager {
   }
 
   private async readFromCacheOnly<T>(key: string): Promise<T | undefined> {
-    if (!this.l1Breaker.isOpen()) {
-      try {
-        const entry = await this.l1.get<CachedEntry<T>>(key);
-        this.l1Breaker.recordSuccess();
-        if (entry && Date.now() < entry.staleUntil) return entry.data;
-      } catch {
-        this.l1Breaker.recordFailure();
-      }
-    }
+    const l1Entry = await this.l1.get<CachedEntry<T>>(key);
+    if (l1Entry && Date.now() < l1Entry.staleUntil) return l1Entry.data;
     if (this.l2 && !this.l2Breaker.isOpen()) {
       try {
         const entry = await this.l2.get<CachedEntry<T>>(key);
@@ -267,7 +251,7 @@ export class CacheManager implements ICacheManager {
 
   async invalidate(key: string): Promise<void> {
     await Promise.allSettled([
-      this.l1Breaker.isOpen() ? Promise.resolve() : this.l1.delete(key),
+      this.l1.delete(key),
       this.l2 && !this.l2Breaker.isOpen() ? this.l2.delete(key) : Promise.resolve(),
       this.relay ? this.relay.publish({ type: 'key', key }) : Promise.resolve(),
     ]);
@@ -275,7 +259,7 @@ export class CacheManager implements ICacheManager {
 
   async invalidateByPrefix(prefix: string): Promise<void> {
     await Promise.allSettled([
-      this.l1Breaker.isOpen() ? Promise.resolve() : this.l1.deleteByPrefix(prefix),
+      this.l1.deleteByPrefix(prefix),
       this.l2 && !this.l2Breaker.isOpen() ? this.l2.deleteByPrefix(prefix) : Promise.resolve(),
       this.relay
         ? this.relay.publish({ type: 'prefix', prefix })

--- a/tests/units/infrastructure/services/cache-manager.service.test.ts
+++ b/tests/units/infrastructure/services/cache-manager.service.test.ts
@@ -109,26 +109,6 @@ describe('CacheManager – L1 only', () => {
     expect(fetcher).toHaveBeenCalledTimes(5); // session still cached
   });
 
-  it('opens the L1 circuit breaker after 5 failures and bypasses L1', async () => {
-    const l1: ICacheStore = {
-      getName: () => 'failing',
-      get: vi.fn().mockRejectedValue(new Error('down')),
-      set: vi.fn().mockResolvedValue(undefined),
-      delete: vi.fn().mockResolvedValue(undefined),
-      deleteByPrefix: vi.fn().mockResolvedValue(undefined),
-    };
-    const manager = new CacheManager(l1);
-    const fetcher = vi.fn().mockResolvedValue('ok');
-
-    for (let i = 0; i < 5; i++) {
-      await manager.get('k', fetcher, { ttlMs: 60_000 });
-    }
-    expect(l1.get).toHaveBeenCalledTimes(5);
-
-    // 6th call – circuit is open, L1 should be bypassed
-    await manager.get('k', fetcher, { ttlMs: 60_000 });
-    expect(l1.get).toHaveBeenCalledTimes(5);
-  });
 });
 
 describe('CacheManager – L1 + L2', () => {


### PR DESCRIPTION
## Summary

- `InMemoryCacheStore` is backed by a synchronous `Map` — every operation (`get`, `set`, `delete`, `deleteByPrefix`) resolves immediately with no network or I/O involved, so it cannot throw in practice.
- The `l1Breaker` field and all four call sites that checked it (`get()`, `readFromCacheOnly()`, `invalidate()`, `invalidateByPrefix()`) have been removed.
- The L2 circuit breaker (Redis / Upstash) is retained unchanged — it guards against real network failures.
- The test that asserted L1 circuit-breaker behaviour has been deleted (it was testing a property the store no longer has).

## Test plan

- [ ] `yarn tsc --noEmit` passes
- [ ] `yarn test --run` — no new failures vs. main