### PR TITLE
feat: XFetch probabilistic early recomputation in CacheManager

### DIFF
--- a/src/application/services/cache-manager.service.interface.ts
+++ b/src/application/services/cache-manager.service.interface.ts
@@ -3,6 +3,12 @@ export interface CacheOptions {
   staleTtlMs?: number;
   jitter?: number;
   lockTimeoutMs?: number;
+  /**
+   * XFetch beta parameter (default 1). Higher values trigger early
+   * recomputation more aggressively, reducing stampede risk at the cost of
+   * slightly more background fetches. Set to 0 to disable XFetch entirely.
+   */
+  beta?: number;
 }
 
 export interface ICacheManager {

--- a/src/infrastructure/services/cache-manager.service.ts
+++ b/src/infrastructure/services/cache-manager.service.ts
@@ -11,6 +11,8 @@ interface CachedEntry<T> {
   data: T;
   freshUntil: number;
   staleUntil: number;
+  /** Milliseconds the original fetch took — used by the XFetch algorithm. */
+  delta: number;
 }
 
 class CircuitBreaker {
@@ -89,6 +91,10 @@ export class CacheManager implements ICacheManager {
     if (l1Entry) {
       const now = Date.now();
       if (now < l1Entry.freshUntil) {
+        if (this.xfetchShouldRecompute(l1Entry, options.beta ?? 1)) {
+          // Probabilistically refresh before expiry to avoid a future stampede.
+          this.triggerRevalidation(key, fetcher, options);
+        }
         this.instrumentation?.recordMetric('cache.hit', { store: 'l1', type: 'fresh' });
         return l1Entry.data;
       }
@@ -108,6 +114,9 @@ export class CacheManager implements ICacheManager {
           if (now < entry.staleUntil) {
             void this.setInStore(this.l1, key, entry, entry.staleUntil - now);
             if (now < entry.freshUntil) {
+              if (this.xfetchShouldRecompute(entry, options.beta ?? 1)) {
+                this.triggerRevalidation(key, fetcher, options);
+              }
               this.instrumentation?.recordMetric('cache.hit', { store: 'l2', type: 'fresh' });
               return entry.data;
             }
@@ -188,9 +197,11 @@ export class CacheManager implements ICacheManager {
     fetcher: () => Promise<T>,
     options: CacheOptions
   ): Promise<T> {
+    const fetchStart = Date.now();
     const tracked = fetcher()
       .then(async (data) => {
-        await this.writeToStores(key, data, options);
+        const delta = Date.now() - fetchStart;
+        await this.writeToStores(key, data, options, delta);
         return data;
       })
       .finally(() => {
@@ -215,7 +226,8 @@ export class CacheManager implements ICacheManager {
   private async writeToStores<T>(
     key: string,
     data: T,
-    options: CacheOptions
+    options: CacheOptions,
+    delta = 0
   ): Promise<void> {
     const now = Date.now();
     const freshMs = this.applyJitter(options.ttlMs, options.jitter ?? 0);
@@ -225,6 +237,7 @@ export class CacheManager implements ICacheManager {
       data,
       freshUntil: now + freshMs,
       staleUntil: now + freshMs + staleMs,
+      delta,
     };
 
     await Promise.allSettled([
@@ -246,6 +259,18 @@ export class CacheManager implements ICacheManager {
     } catch {
       // silently ignore write failures — cache is best-effort
     }
+  }
+
+  // XFetch: probabilistically decide whether to refresh a still-fresh entry.
+  // Formula: now − delta × beta × ln(rand) ≥ freshUntil
+  // ln(rand) is always negative, so the left side exceeds `now`. As freshUntil
+  // approaches, the inequality becomes easier to satisfy. Expensive fetches
+  // (large delta) also increase urgency. beta=0 disables XFetch entirely.
+  private xfetchShouldRecompute(entry: CachedEntry<unknown>, beta: number): boolean {
+    if (beta === 0) return false;
+    // When delta=0, the formula reduces to `now >= freshUntil` which is false
+    // for a fresh entry — so zero-delta entries are handled correctly by the math.
+    return Date.now() - entry.delta * beta * Math.log(Math.random()) >= entry.freshUntil;
   }
 
   private applyJitter(valueMs: number, jitter: number): number {

--- a/tests/units/infrastructure/services/cache-manager.service.test.ts
+++ b/tests/units/infrastructure/services/cache-manager.service.test.ts
@@ -111,6 +111,61 @@ describe('CacheManager – L1 only', () => {
 
 });
 
+describe('CacheManager – XFetch', () => {
+  // Seed L1 directly so we control delta precisely.
+  // XFetch triggers when: now − delta × beta × ln(rand) ≥ freshUntil
+  // With rand = Number.EPSILON, ln(epsilon) ≈ −36.04.
+  // So: delta × 36 must exceed the remaining TTL for the check to fire.
+  // Example: delta=100ms, ttlMs=1_000ms → 100×36=3600 > 1000 ✓
+  function seedL1(l1: InMemoryCacheStore, delta: number, ttlMs: number) {
+    const now = Date.now();
+    return l1.set('k', { data: 'v1', freshUntil: now + ttlMs, staleUntil: now + ttlMs * 2, delta }, ttlMs * 2);
+  }
+
+  it('returns the cached value immediately and triggers background recompute', async () => {
+    const l1 = new InMemoryCacheStore();
+    const manager = new CacheManager(l1);
+    await seedL1(l1, 100, 1_000); // delta=100ms, ttl=1s → 100×36 >> 1000 ✓
+
+    vi.spyOn(Math, 'random').mockReturnValue(Number.EPSILON);
+    const fetcher = vi.fn().mockResolvedValue('v2');
+    const result = await manager.get('k', fetcher, { ttlMs: 1_000, beta: 1 });
+
+    expect(result).toBe('v1');        // returns cached value immediately
+    expect(fetcher).toHaveBeenCalledTimes(1); // background revalidation fired
+    vi.restoreAllMocks();
+  });
+
+  it('does not trigger early recompute when beta is 0', async () => {
+    const l1 = new InMemoryCacheStore();
+    const manager = new CacheManager(l1);
+    await seedL1(l1, 100, 1_000);
+
+    vi.spyOn(Math, 'random').mockReturnValue(Number.EPSILON);
+    const fetcher = vi.fn().mockResolvedValue('v2');
+    await manager.get('k', fetcher, { ttlMs: 1_000, beta: 0 });
+
+    expect(fetcher).not.toHaveBeenCalled(); // XFetch disabled
+    vi.restoreAllMocks();
+  });
+
+  it('does not trigger when delta is 0 (entry populated externally)', async () => {
+    const l1 = new InMemoryCacheStore();
+    const manager = new CacheManager(l1);
+    const now = Date.now();
+    // delta=0: now − 0 × … = now, which is never ≥ freshUntil while fresh
+    await l1.set('k', { data: 'external', freshUntil: now + 60_000, staleUntil: now + 120_000, delta: 0 }, 120_000);
+
+    vi.spyOn(Math, 'random').mockReturnValue(Number.EPSILON);
+    const fetcher = vi.fn().mockResolvedValue('new');
+    const result = await manager.get('k', fetcher, { ttlMs: 60_000, beta: 1 });
+
+    expect(result).toBe('external');
+    expect(fetcher).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
+  });
+});
+
 describe('CacheManager – L1 + L2', () => {
   it('returns the L2 value on an L1 miss and backfills L1', async () => {
     const l1 = new InMemoryCacheStore();


### PR DESCRIPTION
## What

XFetch ([Vattani et al.](https://cseweb.ucsd.edu/~avattani/papers/cache_stampede.pdf)) eliminates the need to wait until an entry goes stale before refreshing. Instead it probabilistically triggers a background revalidation while the entry is still fresh — the probability grows as expiry approaches and scales with the cost of the fetch.

## Formula

```
now − delta × beta × ln(rand) ≥ freshUntil
```

| Variable | Meaning |
|---|---|
| `delta` | ms the original fetch took (stored in `CachedEntry`) |
| `beta` | tuning knob on `CacheOptions` (default `1`; `0` disables XFetch) |
| `ln(rand)` | always negative, so LHS always exceeds `now` |
| `freshUntil` | when the current entry expires |

As `freshUntil` approaches, the inequality becomes easier to satisfy. Expensive fetches (large `delta`) also increase urgency.

## Behaviour

- Fresh entry, XFetch says no → return immediately, no background work.
- Fresh entry, XFetch says yes → return immediately **and** trigger background revalidation.
- Stale entry (`freshUntil < now < staleUntil`) → existing SWR path (unchanged).
- Expired entry → synchronous fetch (unchanged).
- `delta = 0` (externally seeded or sub-ms fetch) → formula reduces to `now ≥ freshUntil`, which is false for a fresh entry. Works correctly without a special-case guard.

## Changes

- `CacheOptions.beta?: number` — tuning parameter (default `1`).
- `CachedEntry.delta: number` — recorded via `Date.now()` around the fetcher call in `startFetch`.
- `CacheManager.xfetchShouldRecompute()` — private method implementing the formula.
- XFetch check inserted at both L1 and L2 fresh-hit paths.

## Test plan

- [ ] `yarn tsc --noEmit` passes
- [ ] `yarn test tests/units/infrastructure/services/cache-manager.service.test.ts --run` — all 16 pass (3 new XFetch cases)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional cache tuning for earlier background refreshes, helping reduce cache stampedes and keep results fresh.
  * Introduced a new setting to control how aggressively early recomputation happens, including the ability to disable it.

* **Bug Fixes**
  * Cache hits may now trigger refreshes before expiry when appropriate, improving consistency for frequently accessed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->