### PR TITLE
ci: add dependency security audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,4 +35,9 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Audit dependencies for high/critical vulnerabilities
-        run: yarn audit --level high
+        # yarn audit exit codes are a severity bitmask: 2=low, 4=moderate, 8=high, 16=critical.
+        # --level high filters the printed report; the exit code still reflects all severities
+        # found, so we inspect the bitmask manually and only fail on high (8) or critical (16).
+        run: |
+          yarn audit --level high || code=$?
+          if [ $(( ${code:-0} & 24 )) -ne 0 ]; then exit 1; fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,38 @@
+name: Security
+
+on:
+  push:
+  schedule:
+    # Run every Monday at 06:00 UTC to catch newly disclosed vulnerabilities
+    # even when the codebase hasn't changed.
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+          cache: 'yarn'
+
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: yarn install --frozen-lockfile
+
+      - name: Audit dependencies for high/critical vulnerabilities
+        run: yarn audit --level high


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/security.yml` with a `dependency-audit` job that runs `yarn audit --level high`
- Fails the check if any **high** or **critical** severity vulnerabilities are found in the dependency tree
- Runs on every push (same as the Test workflow) so new high/critical vulns are caught on PRs before merge
- Also runs on a weekly schedule (Mondays at 06:00 UTC) to surface newly disclosed vulnerabilities even when the codebase hasn't changed

## Notes

GitHub's Dependabot scanner currently reports 12 vulnerabilities on `main` (1 critical, 4 high). This workflow will flag those — they should be resolved via `yarn upgrade` or `yarn audit fix` as a follow-up.

## Test plan

- [ ] Confirm the `Security` workflow appears in GitHub Actions after merge
- [ ] Confirm the `dependency-audit` job runs on push and reports vulnerability counts
- [ ] Resolve existing high/critical vulnerabilities flagged on `main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security checks to regularly monitor project dependencies for high and critical vulnerabilities.
  * Checks now run after code updates and on a weekly schedule, helping identify potential security risks earlier.
  * No user-facing functionality or visual changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->